### PR TITLE
Use zipped libs to deal with aws size limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,21 @@ custom:
   dockerizePip: true
 ```
 
+## ZipImport!
+To help deal with potentially large dependencies (for example: `numpy`, `scipy`
+and `scikit-learn`) there is support for having python import using
+[zipimport](https://docs.python.org/2.7/library/zipimport.html). To enable this
+add the following to your  `serverless.yml`:
+```yaml
+custom:
+  zipImport: true
+```
+
+
 ## Limitations
- * if using the `package` directive in `serverless.yml` ensure that `.requirements` and `requirements.py` are included.
+ * if using the `package` directive in `serverless.yml` ensure that
+`requirements.py` is are included as well as `.requirements` or
+`.requirements.zip` if using [ZipImport](#zipimport).
 
 
 ## Manual invocations

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ and the [docker-lambda](https://github.com/lambci/docker-lambda) image.
 To enable docker usage, add the following to your `serverless.yml`:
 ```yaml
 custom:
-  dockerizePip: true
+  pythonRequirements:
+    dockerizePip: true
 ```
 
 ## ZipImport!
@@ -48,7 +49,8 @@ and `scikit-learn`) there is support for having python import using
 add the following to your  `serverless.yml`:
 ```yaml
 custom:
-  zipImport: true
+  pythonRequirements:
+    zipImport: true
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const _ = require('lodash');
 const path = require('path');
 const fse = require('fs-extra');
 const child_process = require('child_process');
-const {EasyZip} = require('easy-zip');
+const Zip = require('adm-zip');
 
 BbPromise.promisifyAll(fse);
 
@@ -57,18 +57,11 @@ class ServerlessPythonRequirements {
     return this.installRequirements().then(() => {
       return new BbPromise((resolve, reject) => {
         if (this.serverless.service.custom && this.serverless.service.custom.zipImport) {
-          const zip = new EasyZip();
-          zip.zipFolder('.requirements', (err) => {
-            if (err) {
-              reject();
-              return;
-            }
-            zip.writeToFile('.requirements.zip');
-            fse.remove('.requirements', (err) => err?reject():resolve());
-          }, {rootFolder: '.'});
-        } else {
-          resolve();
-        }
+          const zip = new Zip();
+          zip.addLocalFolder('.requirements', '');
+          zip.writeZip('.requirements.zip');
+          fse.remove('.requirements', (err) => err?reject():resolve());
+        } else resolve();
       });
     });
   }

--- a/index.js
+++ b/index.js
@@ -33,8 +33,7 @@ class ServerlessPythonRequirements {
         '-t', '.requirements',
         '-r', 'requirements.txt',
       ];
-      if (this.serverless.service.custom &&
-          this.serverless.service.custom.dockerizePip) {
+      if (this.custom.dockerizePip) {
         cmd = 'docker';
         options = [
           'run', '--rm',
@@ -56,7 +55,7 @@ class ServerlessPythonRequirements {
   packRequirements() {
     return this.installRequirements().then(() => {
       return new BbPromise((resolve, reject) => {
-        if (this.serverless.service.custom && this.serverless.service.custom.zipImport) {
+        if (this.custom.zipImport) {
           const zip = new Zip();
           zip.addLocalFolder('.requirements', '');
           zip.writeZip('.requirements.zip');
@@ -68,7 +67,7 @@ class ServerlessPythonRequirements {
 
   cleanup() {
     const artifacts = ['requirements.py'];
-    if (this.serverless.service.custom && this.serverless.service.custom.zipImport)
+    if (this.custom.zipImport)
       artifacts.push('.requirements.zip')
     else
       artifacts.push('.requirements')
@@ -94,6 +93,7 @@ class ServerlessPythonRequirements {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
+    this.custom = this.serverless.service.custom && this.serverless.service.custom.pythonRequirements || {};
 
     this.commands = {
       'requirements': {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {},
   "dependencies": {
     "bluebird": "^3.0.6",
-    "easy-zip": "github:owenchong/easy-zip",
+    "adm-zip": "0.4.7",
     "fs-extra": "^0.26.7",
     "lodash": "^4.13.1"
   }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {},
   "dependencies": {
     "bluebird": "^3.0.6",
+    "easy-zip": "github:owenchong/easy-zip",
     "fs-extra": "^0.26.7",
     "lodash": "^4.13.1"
   }

--- a/requirements.py
+++ b/requirements.py
@@ -3,9 +3,12 @@ import sys
 
 
 requirements = os.path.join(
-    os.path.split(__file__)[0],
-    '.requirements',
-)
+    os.path.split(__file__)[0], '.requirements')
+zip_requirements = os.path.join(
+    os.path.split(__file__)[0], '.requirements.zip')
 
-if requirements  not in sys.path:
+if requirements not in sys.path:
     sys.path.append(requirements)
+
+if zip_requirements not in sys.path:
+    sys.path.append(zip_requirements)


### PR DESCRIPTION
Leverages Python's [zipimport](https://docs.python.org/2.7/library/zipimport.html). Currently using github master of easy-zip, should probably be using something from NPM. 

Closes #3

@amitaymolko, thoughts? This makes the unzipped size of dependencies not count against the 250Mb deflated limit for lambdas.

todo: 
- [x] better zip lib.
- [x] update docs.
- [x] wrap custom variables in their own section