### PR TITLE
Ability to have separate local / live builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ class ServerlessPythonRequirements {
     return new BbPromise((resolve, reject) => {
       let cmd = 'pip';
       let options = [
-        'install',
+        '--isolated', 'install',
         '-t', '.requirements',
         '-r', 'requirements.txt',
         '-U', '--upgrade-strategy=only-if-needed'

--- a/requirements.py
+++ b/requirements.py
@@ -7,5 +7,11 @@ requirements = os.path.join(
     '.requirements',
 )
 
-if requirements  not in sys.path:
-    sys.path.append(requirements)
+local_requirements = os.path.join(
+    os.path.split(__file__)[0],
+    '.local_requirements',
+)
+
+for path in [requirements, local_requirements]:
+    if os.path.isdir(path) and path not in sys.path:
+        sys.path.insert(1, path)


### PR DESCRIPTION
## Summary
I'm developing a service that uses Pillow, and the dynamic libraries installed only worked when invoked on either my development laptop (OSX) or on AWS, never both, depending on if I compiled using the docker container or not. Having the ability to locally invoke while I'm developing is crucial for speed, so I decided to implement this.

## Changes

* `sls requirements install local` will install dependencies to `.local_requirements` using the host machine, even if `dockerizePip` is enabled.
* `requirements.py` now adds either or both of `.requirements` and `.local_requirements` depending on if they exist or not. If `.local_requirements` exists it will take precedence. Right now I have `.local_requirements` in my `package: exclude:`, but I'm not sure if there's any way to force exclude it somehow within the plugin logic.

## Other stuff
These are only semi-related to this feature, but I threw them in here anyway as I see them as needed improvements- I can remove if necessary.
* Added `--isolated` flag to pip to ensure that no global pip settings interfere with installation
* Added `-U` and `--upgrade-strategy=only-if-needed` as there is no API for updating packages

I can update the docs, but I wanted feedback on this before I take the time to do that.

Thanks!