### PR TITLE
Run dockerized pip as invoking user

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ class ServerlessPythonRequirements {
       ];
       const dockerCmd = [
         'docker', 'run', '--rm',
+        '-u', process.getuid() + ':' + process.getgid(),
         '-v', `${this.serverless.config.servicePath}:/var/task:z`,
         'lambci/lambda:build-python2.7',
         'bash', '-c',


### PR DESCRIPTION
By default docker executes commands in an container as root. This causes the downloaded dependencies to be owned by root. This messes up cleanup scripts.

Using the correct object which holds the dockerizePip option.
this.serverless.service.custom.dockerizePip

Initialize the this.serverless.service.package.exclude and this.serverless.service.package.include correctly if they are not set.