### PR TITLE
Build requirements for "deploy function" calls, too.

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,20 +147,23 @@ class ServerlessPythonRequirements {
       },
     };
 
-    this.hooks = {
-      'before:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
+    let before = () => BbPromise.bind(this)
         .then(this.addVendorHelper)
         .then(this.packRequirements)
-        .then(this.linkRequirements),
+        .then(this.linkRequirements);
 
-      'after:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
+    let after = () => BbPromise.bind(this)
         .then(this.removeVendorHelper)
-        .then(this.unlinkRequirements),
+        .then(this.unlinkRequirements);
 
+    this.hooks = {
+      'before:deploy:createDeploymentArtifacts': before,
+      'after:deploy:createDeploymentArtifacts': after,
+      'before:deploy:function:packageFunction': before,
+      'after:deploy:function:packageFunction': after,
       'requirements:install:install': () => BbPromise.bind(this)
         .then(this.addVendorHelper)
         .then(this.packRequirements),
-
       'requirements:clean:clean': () => BbPromise.bind(this)
         .then(this.cleanup)
         .then(this.removeVendorHelper)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-python-requirements",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Running "deploy function" is much faster if your serverless.yml and config hasn't changed, but the package it builds won't include requirements unless we hook into that event.

This adds the functionality to hook into the function deploy as well.