### PR TITLE
Add invalidateCaches option for frequently updating library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ behind to speed things up on subsequent deploys. To clean them up, run
 `sls requirements clean`. You can also create them (and `unzip_requirements` if
 using zip support) manually with `sls requirements install`.
 
+## Invalidate requirements caches on package
+
+If you are using your own Python library, you have to cleanup
+`.requirements` on any update. You can use the following option to cleanup
+`.requirements` everytime you package.
+
+```
+custom:
+  pythonRequirements:
+    invalidateCaches: true
+```
 
 ## Updating to python 3.6
 

--- a/index.js
+++ b/index.js
@@ -195,6 +195,7 @@ class ServerlessPythonRequirements {
     return Object.assign({
       zip: false,
       cleanupZipHelper: true,
+      invalidateCaches: false,
     }, this.serverless.service.custom &&
     this.serverless.service.custom.pythonRequirements || {});
   }
@@ -244,8 +245,19 @@ class ServerlessPythonRequirements {
     let after = () => BbPromise.bind(this)
         .then(this.removeVendorHelper)
         .then(this.unlinkRequirements);
+    
+    let invalidateCaches = () => {
+      if (this.custom().invalidateCaches) {
+        return BbPromise.bind(this)
+          .then(this.cleanup)
+          .then(this.removeVendorHelper)
+      } else {
+        return BbPromise.resolve()
+      }
+    }
 
     this.hooks = {
+      'after:package:cleanup': invalidateCaches,
       'before:package:createDeploymentArtifacts': before,
       'after:package:createDeploymentArtifacts': after,
       'before:deploy:function:packageFunction': before,


### PR DESCRIPTION
This PR gives option to do `cleanup` on every `cleanup` lifecycle.
It's for users using frequently updating Python library, e.g. common local library which Lambda functions depend on.

closes #37 
