### PR TITLE
Fix error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,9 +145,11 @@ class ServerlessPythonRequirements {
           try {
             linkDest = fse.readlinkSync(`./${file}`);
           } catch (e) {}
-          if (linkDest !== `.requirements/${file}`)
-          throw new Error(`Unable to link dependency '${file}' because a file
-                          by the same name exists in this service`);
+          if (linkDest !== `.requirements/${file}`) {
+            const errorMessage = `Unable to link dependency '${file}' because a file ` +
+              'by the same name exists in this service';
+            throw new Error(errorMessage);
+          }
         }
       });
     }

--- a/index.js
+++ b/index.js
@@ -146,8 +146,8 @@ class ServerlessPythonRequirements {
             linkDest = fse.readlinkSync(`./${file}`);
           } catch (e) {}
           if (linkDest !== `.requirements/${file}`) {
-            const errorMessage = `Unable to link dependency '${file}' because a file ` +
-              'by the same name exists in this service';
+            const errorMessage = `Unable to link dependency '${file}' ` +
+              'because a file by the same name exists in this service';
             throw new Error(errorMessage);
           }
         }


### PR DESCRIPTION
Before modification, there was meaningless line break.
Example:
```
  Error --------------------------------------------------

  Unable to link dependency 'hoge' because a file
                             by the same name exists in this service
```

I fixed it.
Example:
```
  Error --------------------------------------------------

  Unable to link dependency 'hoge' because a file by the same name exists in this service
```