### PR TITLE
run pip commands in container as user '0'

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ class ServerlessPythonRequirements {
           `${image}`,
         ];
         if (process.platform === 'linux')
-          options.push('-u', `${process.getuid()}:${process.getgid()}`);
+          options.push('-u', '0');
         options.push(...pipCmd);
       } else {
         cmd = pipCmd[0];


### PR DESCRIPTION
Hello,

This is a really useful serverless plugin, thanks for sharing.

I use docker-machine via homebrew on Mac OS X 10.12.6. 

When I enabled the cross-compile, the docker container would complain about having permissions to `/var/tasks`.

I'm proposing that the container runs as `root` to avoid these errors and not the UID of the process.

Thanks, let me know!

```
Serverless: Docker Image: lambci/lambda:build-python3.6
 
  Error --------------------------------------------------
 
  Unable to find image 'lambci/lambda:build-python3.6' locally
build-python3.6: Pulling from lambci/lambda
cf9c84c367d8: Pulling fs layer
aeeaf5aea2af: Pulling fs layer
3327455de315: Pulling fs layer
130b553845f2: Pulling fs layer
130b553845f2: Waiting
aeeaf5aea2af: Verifying Checksum
aeeaf5aea2af: Download complete
130b553845f2: Verifying Checksum
130b553845f2: Download complete
3327455de315: Verifying Checksum
3327455de315: Download complete
cf9c84c367d8: Verifying Checksum
cf9c84c367d8: Download complete
cf9c84c367d8: Pull complete
aeeaf5aea2af: Pull complete
3327455de315: Pull complete
130b553845f2: Pull complete
Digest: sha256:0413fab67a1cad400e66b1a9cdd90c77130c058ae0e34f1ecaa0fcae5385bf87
Status: Downloaded newer image for lambci/lambda:build-python3.6
The directory '/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
The directory '/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Exception:
Traceback (most recent call last):
  File "/var/lang/lib/python3.6/site-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/var/lang/lib/python3.6/site-packages/pip/commands/install.py", line 388, in run
    ensure_dir(options.target_dir)
  File "/var/lang/lib/python3.6/site-packages/pip/utils/__init__.py", line 83, in ensure_dir
    os.makedirs(path)
  File "/var/lang/lib/python3.6/os.py", line 220, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/var/task/.requirements'
```