### PR TITLE
fix bug with docker when linux -u options are appended

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,10 +117,10 @@ class ServerlessPythonRequirements {
         options = [
           'run', '--rm',
           '-v', `${this.serverless.config.servicePath}:/var/task:z`,
-          `${image}`,
         ];
         if (process.platform === 'linux')
           options.push('-u', `${process.getuid()}:${process.getgid()}`);
+        options.push(`${image}`);
         options.push(...pipCmd);
       } else {
         cmd = pipCmd[0];


### PR DESCRIPTION
The linux conditional options were being appended after the docker image had been declared, therefore breaking proper docker run syntax.