### PR TITLE
Delay package exclude list manipulation

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,6 +272,17 @@ class ServerlessPythonRequirements {
   };
 
   /**
+   * Inject '.requirements' folder into serverless package exclude list.
+   */
+  excludeRequirementsFolder() {
+    if (!_.get(this.serverless.service, 'package.exclude'))
+      _.set(this.serverless.service, ['package', 'exclude'], []);
+    this.serverless.service.package.exclude.push('.requirements/**');
+    if (!_.get(this.serverless.service, 'package.include'))
+      _.set(this.serverless.service, ['package', 'include'], []);
+  }
+
+  /**
    * get the custom.pythonRequirements contents, with defaults set
    * @return {Object}
    */
@@ -306,12 +317,6 @@ class ServerlessPythonRequirements {
     this.serverless = serverless;
     this.options = options;
 
-    if (!_.get(this.serverless.service, 'package.exclude'))
-      _.set(this.serverless.service, ['package', 'exclude'], []);
-    this.serverless.service.package.exclude.push('.requirements/**');
-    if (!_.get(this.serverless.service, 'package.include'))
-      _.set(this.serverless.service, ['package', 'include'], []);
-
     this.commands = {
       requirements: {
         commands: {
@@ -342,6 +347,7 @@ class ServerlessPythonRequirements {
     };
 
     const before = () => BbPromise.bind(this)
+      .then(this.excludeRequirementsFolder)
       .then(this.addVendorHelper)
       .then(this.packRequirements)
       .then(this.installPipfile)


### PR DESCRIPTION
We use a serverless variable to specify our package exclude list depending on some command line flags. Serverless variables are not yet resolved in the constructor of a plugin (see note [at the bottom of this](https://serverless.com/framework/docs/providers/aws/guide/plugins/#serverless-instance)), leading to the following error:

```
TypeError: this.serverless.service.package.exclude.push is not a function
    at new ServerlessPythonRequirements (/Users/sumpfork/node_modules/serverless-python-requirements/index.js:311:45)
    at PluginManager.addPlugin (/usr/local/lib/node_modules/serverless/lib/classes/PluginManager.js:51:28)
    at plugins.forEach (/usr/local/lib/node_modules/serverless/lib/classes/PluginManager.js:91:14)
    at Array.forEach (<anonymous>)
    at PluginManager.loadPlugins (/usr/local/lib/node_modules/serverless/lib/classes/PluginManager.js:87:13)
    at PluginManager.loadServicePlugins (/usr/local/lib/node_modules/serverless/lib/classes/PluginManager.js:133:10)
    at PluginManager.loadAllPlugins (/usr/local/lib/node_modules/serverless/lib/classes/PluginManager.js:83:10)
    at service.load.then (/usr/local/lib/node_modules/serverless/lib/Serverless.js:64:28)
    at <anonymous>
From previous event:
    at runCallback (timers.js:781:20)
    at tryOnImmediate (timers.js:743:5)
    at processImmediate [as _immediateCallback] (timers.js:714:5)
From previous event:
    at __dirname (/usr/local/lib/node_modules/serverless/bin/serverless:25:46)
    at Object.<anonymous> (/usr/local/lib/node_modules/serverless/bin/serverless:43:4)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Function.Module.runMain (module.js:665:10)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:607:3```

This pull request simply delays manipulating the exclude list to one of the plugin events where variables have already been resolved.