### PR TITLE
Add a hidden option to enable/disable pipenv support.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ class ServerlessPythonRequirements {
       cleanupZipHelper: true,
       invalidateCaches: false,
       fileName: 'requirements.txt',
+      usePipenv: true,
       pythonBin: this.serverless.service.provider.runtime,
       dockerImage: `lambci/lambda:build-${this.serverless.service.provider.runtime}`,
       pipCmdExtraArgs: [],

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -8,7 +8,8 @@ const {spawnSync} = require('child_process');
  */
 function installRequirements() {
   let fileName = this.options.fileName;
-  if (fse.existsSync(path.join(this.servicePath, 'Pipfile'))) {
+  let usePipenv = this.options.usePipenv;
+  if (usePipenv && fse.existsSync(path.join(this.servicePath, 'Pipfile'))) {
     fileName = '.serverless/requirements.txt';
   }
 

--- a/lib/pipenv.js
+++ b/lib/pipenv.js
@@ -7,7 +7,8 @@ const {spawnSync} = require('child_process');
   * @return {Promise}
   */
 function pipfileToRequirements() {
-  if (!fse.existsSync(path.join(this.servicePath, 'Pipfile')))
+  let usePipenv = this.options.usePipenv;
+  if (!usePipenv || !fse.existsSync(path.join(this.servicePath, 'Pipfile')))
     return;
 
   this.serverless.cli.log('Generating requirements.txt from Pipfile...');


### PR DESCRIPTION
I needed this as a workaround for #85 . Might be useful for others too if they want more control whether or not they should use pipenv for generating the requirements.txt