### PR TITLE
Ignore example generated files/directories

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -19,3 +19,7 @@ var/
 # Serverless directories
 .serverless
 .requirements
+
+# Project ignores
+puck/
+serverless.yml.bak


### PR DESCRIPTION
To prevent accidental inclusion to a commit, ignore the install
directory and copied files created during local testing.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>