### PR TITLE
assume .requirements.zip file is at lambda task root, fall back on the current directory

### DIFF
--- a/unzip_requirements.py
+++ b/unzip_requirements.py
@@ -4,7 +4,7 @@ import zipfile
 
 
 zip_requirements = os.path.join(
-    os.getcwd(), '.requirements.zip')
+    os.environ.get('LAMBDA_TASK_ROOT', os.getcwd()), '.requirements.zip')
 
 tempdir = '/tmp/sls-py-req'
 

--- a/unzip_requirements.py
+++ b/unzip_requirements.py
@@ -4,7 +4,7 @@ import zipfile
 
 
 zip_requirements = os.path.join(
-    os.path.split(__file__)[0], '.requirements.zip')
+    os.getcwd(), '.requirements.zip')
 
 tempdir = '/tmp/sls-py-req'
 


### PR DESCRIPTION
We deploy our code to lambda in subdirectories. When importing `unzip_requirements.py` this results in `os.path.split(__file__)[0]` being empty, but `.requirements.zip` actually being higher up in the directory tree.

I believe it's valid to always assume that `.requirements.zip` is at the path pointed to by the env var `LAMBDA_TASK_ROOT` or else the current working dir for lambda, at least as long as the lambda code doesn't change this before imports? At least this works for our projects, subdirs or not.
