### PR TITLE
Create .serverless folder if missing

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -21,6 +21,7 @@ function installRequirements() {
   // In case the requirements file is a symlink, copy it to .serverless/requirements.txt
   // if using docker to avoid errors
   if (this.options.dockerizePip && fileName !== dotSlsReqs) {
+    fse.ensureDirSync(path.join(this.servicePath, '.serverless'));
     fse.copySync(fileName, dotSlsReqs);
     fileName = dotSlsReqs;
   }


### PR DESCRIPTION
Fix for requirements.txt is not copied to .serverless/requirements.txt when options.dockerizePip = true