### PR TITLE
Fix Windows support for dockerizePip

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -50,9 +50,29 @@ function installRequirements() {
 
     this.serverless.cli.log(`Docker Image: ${this.options.dockerImage}`);
 
+    // Check docker server os type from 'docker version'
+    let volPath;
+    options = [
+      'version', '--format', '{{with .Server}}{{.Os}}{{end}}'
+    ];
+    const ps = spawnSync(cmd, options, {'timeout': 2000, 'encoding': 'utf-8'});
+    if (ps.error) {
+      if (ps.error.code === 'ENOENT') {
+        throw new Error('docker not found! Please install it.');
+      }
+      throw new Error(ps.error);
+    }
+    if (ps.status !== 0) {
+      throw new Error(ps.stderr);
+    } else if (ps.stdout.trim() === 'windows') {
+      volPath = this.servicePath.replace(/\\/g, '/').replace(/^\/mnt\//, '/');
+    } else {
+      volPath = this.servicePath;
+    }
+
     options = [
       'run', '--rm',
-      '-v', `${this.servicePath}:/var/task:z`,
+      '-v', `${volPath}:/var/task:z`,
     ];
     if (process.platform === 'linux')
       options.push('-u', `${process.getuid()}:${process.getgid()}`);


### PR DESCRIPTION
Fix docker volume bind path format, in order to support `Docker for Windows` when using sls/nodejs/docker from Powershell or from Windows Subsystem for Linux (WSL).

Issue #105