### PR TITLE
Handle multi-language projects

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -16,8 +16,24 @@ function linkRequirements() {
     fse.readdirSync(requirementsDir).map((file) => {
       if (noDeploy.has(file))
         return;
-      this.serverless.service.package.include.push(file);
-      this.serverless.service.package.include.push(`${file}/**`);
+      if (this.serverless.service.package.individually) {
+        // don't include python deps in non-python functions
+        _.each(
+          _.filter(
+            this.serverless.service.functions,
+            (f) => { return (f.runtime || this.serverless.service.provider.runtime).match(/^python.*/) }
+          ),
+          (f) => {
+            if (!_.get(f, 'package.include'))
+              _.set(f, ['package', 'include'], []);
+            f.package.include.push(file)
+            f.package.include.push(`${file}/**`)
+          }
+        );
+      } else {
+        this.serverless.service.package.include.push(file);
+        this.serverless.service.package.include.push(`${file}/**`);
+      }
       try {
         fse.symlinkSync(`${requirementsDir}/${file}`, `./${file}`);
       } catch (exception) {


### PR DESCRIPTION
This change looks at the global package options for `individually=True`, which I use if I have multiple different languages for my functions and they all have different packaging rules. For example, I don't want node_modules in any python functions, or my .pyc/pyo/etc files in my nodejs functions. We can discriminate language easily based on the runtime of each function to decide what to do. 

With this check, we can now only add Python requirements to python function `include`s when `individually=True`