### PR TITLE
win32 copy fallback! closes #118

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -39,13 +39,17 @@ function linkRequirements() {
       try {
         fse.symlinkSync(`${requirementsDir}/${file}`, `./${file}`);
       } catch (exception) {
-        let linkDest = null;
-        try {
-          linkDest = fse.readlinkSync(`./${file}`);
-        } catch (e) {
+        if (e.code === 'EPERM' && process.platform !== 'win32') {
+          fse.copySync(`${requirementsDir}/${file}`, `./${file}`);
+        } else {
+          let linkDest = null;
+          try {
+            linkDest = fse.readlinkSync(`./${file}`);
+          } catch (e) {
+          }
+          if (linkDest !== `${requirementsDir}/${file}`)
+            throw exception;
         }
-        if (linkDest !== `${requirementsDir}/${file}`)
-          throw exception;
       }
     });
   }


### PR DESCRIPTION
I added it as a fallback, so the CI doesn't really test it. Mind testing it @nthienan? You can install this PR with:

```
npm install UnitedIncome/serverless-python-requirements#win32-cp
```