### PR TITLE
Add option to used private repos in requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ custom:
 ```
 This must be the full image name and tag to use, including the runtime specific tag if applicable.
 
+
+To use private repositories, add the following to your `serverless.yml`:
+```yaml
+custom:
+  pythonRequirements:
+    dockerizePip: true
+    dockerSshSymlink: /path/to/.ssh
+```
+This must be the path to your folder (usually `~/.ssh`) containing your ssh public and private keys.
+**Caution:** please note, it will only work if you have an empty passphrase!
+
+
 [:checkered_flag: Windows notes](#checkered_flag-windows-dockerizepip-notes)
 
 ## Pipenv support :sparkles::cake::sparkles:

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ To use private repositories, add the following to your `serverless.yml`:
 custom:
   pythonRequirements:
     dockerizePip: true
-    dockerSshSymlink: /path/to/.ssh
+    dockerSsh: true
 ```
-This must be the path to your folder (usually `~/.ssh`) containing your ssh public and private keys.
-**Caution:** please note, it will only work if you have an empty passphrase!
+The dockerSsh option will set a volume in the docker container to be able to use your ssh keys.
+**Caution:** This option will only work if you are using ssh to pull your repos (git+ssh for instance) and this option assumes your `.ssh` folder is located in your home folder (located via the `$HOME` environment variable).
 
 
 [:checkered_flag: Windows notes](#checkered_flag-windows-dockerizepip-notes)

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -86,6 +86,8 @@ function installRequirements() {
       'run', '--rm',
       '-v', `${bindPath}:/var/task:z`,
     ];
+    if (this.options.dockerSshSymlink)
+        options.push('-v', this.options.dockerSshSymlink + ':/root/.ssh')
     if (process.platform === 'linux')
       options.push('-u', `${process.getuid()}:${process.getgid()}`);
     options.push(this.options.dockerImage);

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -86,8 +86,10 @@ function installRequirements() {
       'run', '--rm',
       '-v', `${bindPath}:/var/task:z`,
     ];
-    if (this.options.dockerSshSymlink)
-        options.push('-v', this.options.dockerSshSymlink + ':/root/.ssh')
+    if(this.options.dockerSsh)
+        options.push('-v', process.env.HOME          + '/.ssh:/root/.ssh')
+        options.push('-v', process.env.SSH_AUTH_SOCK + ':/tmp/ssh_sock')
+        options.push('-e', 'SSH_AUTH_SOCK=/tmp/ssh_sock')
     if (process.platform === 'linux')
       options.push('-u', `${process.getuid()}:${process.getgid()}`);
     options.push(this.options.dockerImage);


### PR DESCRIPTION
Add a `dockerSshSymlink` option which is a path to your .ssh folder containing your keys.
If the passphrase is empty, you will be able to package your private repos from the docker container.
Solves #69 ?