### PR TITLE
Fix option to used private repos in requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,12 @@ custom:
     dockerizePip: true
     dockerSsh: true
 ```
-The `dockerSsh` option will mount your `$HOME/.ssh` as a volume in the docker
-container. If your SSH key is password protected, you can use `ssh-agent`
+The `dockerSsh` option will mount your `$HOME/.ssh/id_rsa` and `$HOME/.ssh/known_hosts` as a
+volume in the docker container. If your SSH key is password protected, you can use `ssh-agent`
 because `$SSH_AUTH_SOCK` is also mounted & the env var set.
+It is important that the host of your private repositories has already been added in your
+`$HOME/.ssh/known_hosts` file, as the install process will fail otherwise due to host authenticity
+failure.
 
 [:checkered_flag: Windows notes](#checkered_flag-windows-dockerizepip-notes)
 

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -2,6 +2,7 @@ const fse = require('fs-extra');
 const path = require('path');
 const {spawnSync} = require('child_process');
 const isWsl = require('is-wsl');
+const quote = require('shell-quote').quote;
 
 /**
  * pip install the requirements to the .serverless/requirements directory
@@ -95,8 +96,9 @@ function installRequirements() {
     }
     if (process.platform === 'linux')
       // Set the ownership of the .serverless/requirements folder to current user
-      pipCmd   = pipCmd.join(' ');
-      chownCmd = `chown -R ${process.getuid()}:${process.getgid()} .serverless/requirements`
+      pipCmd   = quote(pipCmd);
+      chownCmd = quote(['chown', '-R', `${process.getuid()}:${process.getgid()}`,
+                        '.serverless/requirements']);
       pipCmd   = ['/bin/bash', '-c', '"' + pipCmd + ' && ' + chownCmd + '"']
     options.push(this.options.dockerImage);
     options.push(...pipCmd);

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -29,8 +29,8 @@ function installRequirements() {
 
   let cmd;
   let options;
-  const pipCmd = [
-    this.options.pythonBin, '-m', 'pip', '--isolated', 'install',
+  let pipCmd = [
+    this.options.pythonBin, '-m', 'pip', '--no-cache-dir', '--isolated', 'install',
     '-t', '.serverless/requirements', '-r', fileName,
     ...this.options.pipCmdExtraArgs,
   ];
@@ -84,22 +84,27 @@ function installRequirements() {
 
     options = [
       'run', '--rm',
-      '-v', `${bindPath}:/var/task:z`,
+      '-v', `${bindPath}:/var/task`,
     ];
     if(this.options.dockerSsh) {
-      options.push('-v', `${process.env.HOME}/.ssh:/root/.ssh:z`);
+      // Mount necessary ssh files to work with private repos
+      options.push('-v', `${process.env.HOME}/.ssh/id_rsa:/root/.ssh/id_rsa:z`);
+      options.push('-v', `${process.env.HOME}/.ssh/known_hosts:/root/.ssh/known_hosts:z`);
       options.push('-v', `${process.env.SSH_AUTH_SOCK}:/tmp/ssh_sock:z`);
       options.push('-e', 'SSH_AUTH_SOCK=/tmp/ssh_sock');
     }
     if (process.platform === 'linux')
-      options.push('-u', `${process.getuid()}:${process.getgid()}`);
+      // Set the ownership of the .serverless/requirements folder to current user
+      pipCmd   = pipCmd.join(' ');
+      chownCmd = `chown -R ${process.getuid()}:${process.getgid()} .serverless/requirements`
+      pipCmd   = ['/bin/bash', '-c', '"' + pipCmd + ' && ' + chownCmd + '"']
     options.push(this.options.dockerImage);
     options.push(...pipCmd);
   } else {
     cmd = pipCmd[0];
     options = pipCmd.slice(1);
   }
-  const res = spawnSync(cmd, options, {cwd: this.servicePath});
+  const res = spawnSync(cmd, options, {cwd: this.servicePath, shell: true});
   if (res.error) {
     if (res.error.code === 'ENOENT') {
       if (this.options.dockerizePip) {

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -2,7 +2,7 @@ const fse = require('fs-extra');
 const path = require('path');
 const {spawnSync} = require('child_process');
 const isWsl = require('is-wsl');
-const quote = require('shell-quote').quote;
+const {quote} = require('shell-quote');
 
 /**
  * pip install the requirements to the .serverless/requirements directory
@@ -96,10 +96,10 @@ function installRequirements() {
     }
     if (process.platform === 'linux')
       // Set the ownership of the .serverless/requirements folder to current user
-      pipCmd   = quote(pipCmd);
+      pipCmd = quote(pipCmd);
       chownCmd = quote(['chown', '-R', `${process.getuid()}:${process.getgid()}`,
                         '.serverless/requirements']);
-      pipCmd   = ['/bin/bash', '-c', '"' + pipCmd + ' && ' + chownCmd + '"']
+      pipCmd = ['/bin/bash', '-c', '"' + pipCmd + ' && ' + chownCmd + '"'];
     options.push(this.options.dockerImage);
     options.push(...pipCmd);
   } else {

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -85,7 +85,7 @@ function installRequirements() {
 
     options = [
       'run', '--rm',
-      '-v', `${bindPath}:/var/task`,
+      '-v', `${bindPath}:/var/task:z`,
     ];
     if(this.options.dockerSsh) {
       // Mount necessary ssh files to work with private repos

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -31,7 +31,7 @@ function installRequirements() {
   let cmd;
   let options;
   let pipCmd = [
-    this.options.pythonBin, '-m', 'pip', '--no-cache-dir', '--isolated', 'install',
+    this.options.pythonBin, '-m', 'pip', '--isolated', 'install',
     '-t', '.serverless/requirements', '-r', fileName,
     ...this.options.pipCmdExtraArgs,
   ];

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
     "lodash.values": "^4.3.0",
-    "rimraf": "^2.6.2"
+    "rimraf": "^2.6.2",
+    "shell-quote": "^1.6.1"
   }
 }


### PR DESCRIPTION
Fix for PR #121 
The initial solution wasn't working due to docker being run as current user.
Docker is now run as root, so the ssh keys mounted in `/root/.ssh` are used, and it is possible to have private repos as requirements.
To still have correct ownership of the created `.serverless/requirements` folder, a `chown` command is run inside the docker container before exiting.

Other notes:
- Removed the `:z` flag when mounting the current directory, in order to be able to create the `.serverless/requirements` folder.
- Mounting the `.ssh/id_rsa` and `.ssh/known_hosts` instead of the whole directory because if you have a `.ssh/config` file, it will break ssh-agent inside the docker container due to restrictive file permission check.