### PR TITLE
 Remove unnecessary `new Error()`

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -44,7 +44,7 @@ function installRequirements() {
         throw new Error(`${this.options.pythonBin} not found! ` +
                       'Try the pythonBin option.');
       }
-      throw new Error(pipTestRes.error);
+      throw pipTestRes.error;
     }
     if (pipTestRes.stdout.toString().indexOf('--system') >= 0) {
       pipCmd.push('--system');
@@ -100,7 +100,7 @@ function installRequirements() {
       }
       throw new Error(`${this.options.pythonBin} not found! Try the pythonBin option.`);
     }
-    throw new Error(res.error);
+    throw res.error;
   }
   if (res.status !== 0) {
     throw new Error(res.stderr);

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -70,7 +70,7 @@ function installRequirements() {
       'run', '--rm',
       '-v', `${bindPath}:/var/task:z`,
     ];
-    if(this.options.dockerSsh) {
+    if (this.options.dockerSsh) {
       // Mount necessary ssh files to work with private repos
       options.push('-v', `${process.env.HOME}/.ssh/id_rsa:/root/.ssh/id_rsa:z`);
       options.push('-v', `${process.env.HOME}/.ssh/known_hosts:/root/.ssh/known_hosts:z`);


### PR DESCRIPTION
The `error` of spawnSync's return value is an object of `Error`.

https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options