### PR TITLE
Fix paths for Docker on Windows

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -40,7 +40,8 @@ function installRequirements(requirementsPath, targetFolder, serverless, service
   let cmdOptions;
   let pipCmd = [
     options.pythonBin, '-m', 'pip', '--isolated', 'install',
-    '-t', dockerPathForWin(options, targetRequirementsFolder), '-r', dockerPathForWin(options, fileName),
+    '-t', dockerPathForWin(options, targetRequirementsFolder),
+    '-r', dockerPathForWin(options, fileName),
     ...options.pipCmdExtraArgs,
   ];
   if (!options.dockerizePip) {
@@ -122,6 +123,12 @@ function installRequirements(requirementsPath, targetFolder, serverless, service
   }
 };
 
+/**
+ * convert path from Windows style to Linux style, if needed
+ * @param {Object} options
+ * @param {string} path
+ * @return {string}
+ */
 function dockerPathForWin(options, path) {
   if (process.platform === 'win32' && options.dockerizePip) {
     return path.replace('\\', '/');

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -40,7 +40,7 @@ function installRequirements(requirementsPath, targetFolder, serverless, service
   let cmdOptions;
   let pipCmd = [
     options.pythonBin, '-m', 'pip', '--isolated', 'install',
-    '-t', targetRequirementsFolder, '-r', fileName,
+    '-t', dockerPathForWin(options, targetRequirementsFolder), '-r', dockerPathForWin(options, fileName),
     ...options.pipCmdExtraArgs,
   ];
   if (!options.dockerizePip) {
@@ -121,6 +121,13 @@ function installRequirements(requirementsPath, targetFolder, serverless, service
     throw new Error(res.stderr);
   }
 };
+
+function dockerPathForWin(options, path) {
+  if (process.platform === 'win32' && options.dockerizePip) {
+    return path.replace('\\', '/');
+  }
+  return path;
+}
 
 /**
  * pip install the requirements to the .serverless/requirements directory


### PR DESCRIPTION
When using on Windows with the default docker configuration, it passes `.serverless\\requirements.txt` to `docker ... pip install ...`. This results in the following error:

```
Could not open requirements file: [Errno 22] Invalid argument: '.serverless\\requirements.txt'
```

To fix this, we can convert the paths from Windows style to Linux style when running on Windows with `dockerZip: true`.