### PR TITLE
set standards with .editorconfig and .gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,json,yml}]
+charset = utf-8
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[package.json]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js    text eol=lf
+*.json  text eol=lf


### PR DESCRIPTION
This makes it easier to develop on Windows and other IDEs by setting a standard for line breaks, spacing and encoding. Manual editing is required without this for `eslint` to pass.