### PR TITLE
Fix --cache-dir with Docker

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -3,7 +3,6 @@ const path = require('path');
 const get = require('lodash.get');
 const set = require('lodash.set');
 const {spawnSync} = require('child_process');
-const {quote} = require('shell-quote');
 const values = require('lodash.values');
 const {buildImage, getBindPath} = require('./docker');
 
@@ -87,19 +86,17 @@ function installRequirements(requirementsPath, targetFolder, serverless, service
       cmdOptions.push('-e', 'SSH_AUTH_SOCK=/tmp/ssh_sock');
     }
     if (process.platform === 'linux') {
-      // Set the ownership of the .serverless/requirements folder to current user
-      pipCmd = quote(pipCmd);
-      const chownCmd = quote([
-        'chown', '-R', `${process.getuid()}:${process.getgid()}`,
-        targetRequirementsFolder,
-      ]);
-      pipCmd = ['/bin/bash', '-c', '"' + pipCmd + ' && ' + chownCmd + '"'];
+      // Use same user so requirements folder is not root and so --cache-dir works
+      cmdOptions.push('-u', `${process.getuid()}`);
       // const stripCmd = quote([
       //   'find', targetRequirementsFolder,
       //   '-name', '"*.so"',
       //   '-exec', 'strip', '{}', '\;',
       // ]);
       // pipCmd = ['/bin/bash', '-c', '"' + pipCmd + ' && ' + stripCmd + ' && ' + chownCmd + '"'];
+    } else if (process.platform === 'win32') {
+      // Use same user so --cache-dir works
+      cmdOptions.push('-u', '1000'); // TODO is this always the case?
     }
     cmdOptions.push(dockerImage);
     cmdOptions.push(...pipCmd);


### PR DESCRIPTION
Without supplying a user Docker defaulted to `root`
That caused pip to refuse to use any specified `--cache-dir` because it's owned by the user
Run Docker as the user so it has proper access to any `--cache-dir`