### PR TITLE
Speed up requirements installation by skipping noDeploy

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -22,25 +22,19 @@ function installRequirements(requirementsPath, targetFolder, serverless, service
   fse.ensureDirSync(targetRequirementsFolder);
 
   const dotSlsReqs = path.join(targetFolder, 'requirements.txt');
-  let fileName = requirementsPath;
   if (options.usePipenv && fse.existsSync(path.join(servicePath, 'Pipfile'))) {
-    fileName = dotSlsReqs;
+    generateRequirementsFile(dotSlsReqs, dotSlsReqs, options);
+  } else {
+    generateRequirementsFile(requirementsPath, dotSlsReqs, options);
   }
 
   serverless.cli.log(`Installing requirements of ${requirementsPath} in ${targetFolder}...`);
-
-  // In case the requirements file is a symlink, copy it to targetFolder
-  // if using docker to avoid errors
-  if (options.dockerizePip && fileName !== dotSlsReqs) {
-    fse.copySync(fileName, dotSlsReqs);
-    fileName = dotSlsReqs;
-  }
 
   let cmd;
   let cmdOptions;
   let pipCmd = [
     options.pythonBin, '-m', 'pip', '--isolated', 'install',
-    '-t', targetRequirementsFolder, '-r', fileName,
+    '-t', targetRequirementsFolder, '-r', dotSlsReqs,
     ...options.pipCmdExtraArgs,
   ];
   if (!options.dockerizePip) {
@@ -121,6 +115,21 @@ function installRequirements(requirementsPath, targetFolder, serverless, service
     throw new Error(res.stderr);
   }
 };
+
+/**
+ * create a filtered requirements.txt without anything from noDeploy
+ * @param {string} source requirements
+ * @param {string} target requirements where results are written
+ * @param {Object} options
+ */
+function generateRequirementsFile(source, target, options) {
+  const noDeploy = new Set(options.noDeploy || []);
+  const requirements = fse.readFileSync(source, {encoding: 'utf-8'}).split(/\r?\n/);
+  const filteredRequirements = requirements.filter((req) => {
+    return !noDeploy.has(req.split(/[=<> \t]/)[0].trim());
+  });
+  fse.writeFileSync(target, filteredRequirements.join('\n'));
+}
 
 /**
  * pip install the requirements to the .serverless/requirements directory


### PR DESCRIPTION
Instead of filtering later, just don't install them