### PR TITLE
Atomically create unzip_requirements package directory to handle partial failure

### DIFF
--- a/unzip_requirements.py
+++ b/unzip_requirements.py
@@ -1,14 +1,20 @@
 import os
+import shutil
 import sys
 import zipfile
 
 
-zip_requirements = os.path.join(
-    os.environ.get('LAMBDA_TASK_ROOT', os.getcwd()), '.requirements.zip')
+pkgdir = '/tmp/sls-py-req'
 
-tempdir = '/tmp/sls-py-req'
+sys.path.append(pkgdir)
 
-sys.path.append(tempdir)
+if not os.path.exists(pkgdir):
+    tempdir = '/tmp/_temp-sls-py-req'
+    if os.path.exists(tempdir):
+        shutil.rmtree(tempdir)
 
-if not os.path.exists(tempdir):
+    zip_requirements = os.path.join(
+        os.environ.get('LAMBDA_TASK_ROOT', os.getcwd()), '.requirements.zip')
+
     zipfile.ZipFile(zip_requirements, 'r').extractall(tempdir)
+    os.rename(tempdir, pkgdir)  # Atomic


### PR DESCRIPTION
Change logic to unzip into a temp directory and only move to the final
package directory on success.  This handles cases where Lambda kills the
container init halfway through, which seems to be a hard process kill
that never hits Python exception handlers.

Uses os.rename, since that is guaranteed to be atomic on Linux.

* Unzip to tempdir
* Make more logic lazy