### PR TITLE
Better error message when Docker is not available

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -61,6 +61,10 @@ function getBindPath(servicePath) {
     return servicePath;
   }
 
+  // test docker is available
+  dockerCommand(['version']);
+
+  // find good bind path for Windows
   let bindPaths = [];
   let baseBindPath = servicePath.replace(/\\([^\s])/g, '/$1');
   let drive;


### PR DESCRIPTION
My last change caused "Unable to find good bind path format" to be printed when Docker was not available or not running. That's not a very helpful message. Try running `docker version` and print the result if it failed for a better error message.