### PR TITLE
Add vendors support

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -12,8 +12,16 @@ BbPromise.promisifyAll(fse);
 function cleanup() {
   const artifacts = ['.requirements'];
   if (this.options.zip) {
-    artifacts.push('.requirements.zip');
-    artifacts.push('unzip_requirements.py');
+    if (this.serverless.service.package.individually) {
+      values(this.serverless.service.functions)
+        .forEach((f) => {
+          artifacts.push(path.join(f.module, '.requirements.zip'));
+          artifacts.push(path.join(f.module, 'unzip_requirements.py'));
+        });
+    } else {
+      artifacts.push('.requirements.zip');
+      artifacts.push('unzip_requirements.py');
+    }
   }
 
   return BbPromise.all(artifacts.map((artifact) => fse.removeAsync(

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -1,4 +1,5 @@
 const fse = require('fs-extra');
+const rimraf = require('rimraf');
 const path = require('path');
 const get = require('lodash.get');
 const set = require('lodash.set');
@@ -8,7 +9,7 @@ const values = require('lodash.values');
 const {buildImage, getBindPath} = require('./docker');
 
 /**
- * Install requirements described in requirementsPath to targetPath
+ * Install requirements described in requirementsPath to targetFolder
  * @param {string} requirementsPath
  * @param {string} targetFolder
  * @param {Object} serverless
@@ -145,6 +146,30 @@ function generateRequirementsFile(source, target, options) {
 }
 
 /**
+ * Copy everything from vendorsFolder to targetFolder
+ * @param {string} vendorsFolder
+ * @param {string} targetFolder
+ * @param {Object} serverless
+ * @return {undefined}
+ */
+function copyVendors(vendorsFolder, targetFolder, serverless) {
+  // Create target folder if it does not exist
+  const targetRequirementsFolder = path.join(targetFolder, 'requirements');
+
+  serverless.cli.log(
+    `Copying vendors libraries from ${vendorsFolder} to ${targetRequirementsFolder}...`);
+
+  fse.readdirSync(vendorsFolder).map((file) => {
+    let source = path.join(vendorsFolder, file);
+    let dest = path.join(targetRequirementsFolder, file);
+    if (fse.existsSync(dest)) {
+      rimraf.sync(dest);
+    }
+    fse.copySync(source, dest);
+  });
+}
+
+/**
  * pip install the requirements to the .serverless/requirements directory
  * @return {undefined}
  */
@@ -165,6 +190,14 @@ function installAllRequirements() {
             this.servicePath,
             this.options
           );
+          if (f.vendors) {
+            // copy vendors libraries to requirements folder
+            copyVendors(
+              f.vendors,
+              path.join('.serverless', f.module),
+              this.serverless
+            );
+          }
           doneModules.push(f.module);
         }
       });
@@ -176,6 +209,14 @@ function installAllRequirements() {
       this.servicePath,
       this.options
     );
+    if (this.options.vendors) {
+      // copy vendors libraries to requirements folder
+      copyVendors(
+        this.options.vendors,
+        '.serverless',
+        this.serverless
+      );
+    }
   }
 };
 


### PR DESCRIPTION
# Reason
For function with Numpy / Scipy / etc. dependencies, we find the fact to zip your requirements to be a less optimal solution than including carefully stripped versions of these libraries.
Indeed, even with the zip option, you can easily reach 90Mo artefact, whereas by using stripped versions, and not even zipping the requirements, the same function's artefact is only 44Mo!

See also #153 for issues with the zipped requirements.

# How to use
You just have to put in a folder the libraries you want to be included in your artefact, and to declare the path to this folder in your serverless.yml (at function level if you use individual packaging).
The process will use pip to download your dependencies as usual, but after that, it will copy the content from your vendor folder.

To prepare your vendors, you can find already stripped version here: https://github.com/Miserlou/lambda-packages
Or follow this tutorial for instance: https://serverlesscode.com/post/scikitlearn-with-amazon-linux-container/

# Additional change
I fixed a bug (I previously introduced) during the cleaning process that cause the .requirements.zip file to not be removed when using individual packaging.