### PR TITLE
Fix corrupted zip archive in case of same module

### DIFF
--- a/lib/inject.js
+++ b/lib/inject.js
@@ -95,7 +95,7 @@ function injectAllRequirements() {
       .map(func => {
         if (func.module !== '.') {
           const artifact = func.package.artifact;
-          const newArtifact = path.join('.serverless', `${func.module}.zip`);
+          const newArtifact = path.join('.serverless', `${func.module}-${func.name}.zip`);
           func.package.artifact = newArtifact;
           return moveModuleUp(artifact, newArtifact, func.module).then(
             () => func

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -95,7 +95,10 @@ function injectAllRequirements() {
       .map(func => {
         if (func.module !== '.') {
           const artifact = func.package.artifact;
-          const newArtifact = path.join('.serverless', `${func.module}-${func.name}.zip`);
+          const newArtifact = path.join(
+            '.serverless',
+            `${func.module}-${func.name}.zip`
+          );
           func.package.artifact = newArtifact;
           return moveModuleUp(artifact, newArtifact, func.module).then(
             () => func

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -201,29 +201,35 @@ function installAllRequirements() {
   fse.ensureDirSync(path.join(this.servicePath, '.serverless'));
   if (this.serverless.service.package.individually) {
     let doneModules = [];
-    values(this.serverless.service.functions).forEach(f => {
-      if (!get(f, 'module')) {
-        set(f, ['module'], '.');
-      }
-      if (!doneModules.includes(f.module)) {
-        installRequirements(
-          path.join(f.module, this.options.fileName),
-          path.join('.serverless', f.module),
-          this.serverless,
-          this.servicePath,
-          this.options
-        );
-        if (f.vendor) {
-          // copy vendor libraries to requirements folder
-          copyVendors(
-            f.vendor,
-            path.join('.serverless', f.module),
-            this.serverless
-          );
+    values(this.serverless.service.functions)
+      .filter(func =>
+        (func.runtime || this.serverless.service.provider.runtime).match(
+          /^python.*/
+        )
+      )
+      .map(f => {
+        if (!get(f, 'module')) {
+          set(f, ['module'], '.');
         }
-        doneModules.push(f.module);
-      }
-    });
+        if (!doneModules.includes(f.module)) {
+          installRequirements(
+            path.join(f.module, this.options.fileName),
+            path.join('.serverless', f.module),
+            this.serverless,
+            this.servicePath,
+            this.options
+          );
+          if (f.vendor) {
+            // copy vendor libraries to requirements folder
+            copyVendors(
+              f.vendor,
+              path.join('.serverless', f.module),
+              this.serverless
+            );
+          }
+          doneModules.push(f.module);
+        }
+      });
   } else {
     installRequirements(
       this.options.fileName,

--- a/test.bats
+++ b/test.bats
@@ -197,8 +197,8 @@ teardown() {
     cd tests/individually
     npm i $(npm pack ../..)
     sls package
-    unzip .serverless/module1.zip -d puck
-    unzip .serverless/module2.zip -d puck2
+    unzip .serverless/module1-sls-py-req-test-indiv.zip -d puck
+    unzip .serverless/module2-sls-py-req-test-indiv.zip -d puck2
     ls puck/handler1.py
     ls puck2/handler2.py
     ls puck/pyaml


### PR DESCRIPTION
Problem
-------

We have different functions with different runtime (not only python) defined in serverless.yml.
For python runtime, there are several functions defined in one file with same dependencies.
To be able to build a package, I have to specify the `module` param, since requirements for our python functions are not placed in a root folder of the project.

Project structure (simplified):
```
my-serverless-project
├── api
│   ├── users
│   │   ├── handlers.py
│   │   └── requirements.txt
│   └── generator
│       └── some-non-python-functions-here
└── serverless.yml
```

In `api/users/handlers.py` we have several functions:

```
def func1(event, context):
    # ...


def func2(event, context):
    # ...
```

serverless.yaml (some directives are omitted for simplicity):
```
package:
  individually: true


  functions:
    generator:
      runtime: non-python
      # ...
    func1:
      handler: handlers.func1
      module: api/users
      runtime: python3.6
      events:
        - http:
            path: one
            method: get
    func2:
      handler: handlers.func2
      module: api/users
      runtime: python3.6
      events:
        - http:
            path: two
            method: get

plugins:
  - serverless-python-requirements

custom:
  pythonRequirements:
    dockerizePip: true
    dockerImage: lambci/lambda:build-python3.6
```

As you can see, both func1 and func2 are declared in same python file, but these are different lambda functions. And they have same dependencies, i.e. same requirmemnts.txt file. We found such code structure useful.

When I try to create a package:
```
sls package
```
The resulting archive in `.serverless/api/users.zip` is corrupted. I suppose the reason is that serverless-python-requirements creates zip archives for different functions asynchronously. Since both functions have same module path - they have same artifact archive.
I can't unzip it and deploy is not working as well.

The archive is fine when I delete func2 from serverless.yml.

Solution
--------
The easiest solution that comes to my mind is to include func name to the artifact zip archive. In that way it works well.