### PR TITLE
Fixed bindPath so paths with white space will work.

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -89,7 +89,7 @@ function installRequirements(
     // Prepare bind path depending on os platform
     const bindPath = getBindPath(servicePath);
 
-    cmdOptions = ['run', '--rm', '-v', `${bindPath}:/var/task:z`];
+    cmdOptions = ['run', '--rm', '-v', `"${bindPath}:/var/task:z"`];
     if (options.dockerSsh) {
       // Mount necessary ssh files to work with private repos
       cmdOptions.push(


### PR DESCRIPTION
Per my issue [here](https://github.com/UnitedIncome/serverless-python-requirements/issues/184), fixed the bindPath to allow for white space.