### PR TITLE
Enabling serverless python requirements to install TA-LIB

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -51,6 +51,11 @@ function installRequirements(
     dockerPathForWin(options, dotSlsReqs),
     ...options.pipCmdExtraArgs
   ];
+
+  pipCmd = pipCmd.concat(['||','true','||'].concat(pipCmd));
+
+  serverless.cli.log(`pip command: ${pipCmd}`);
+
   if (!options.dockerizePip) {
     // Check if pip has Debian's --system option and set it if so
     const pipTestRes = spawnSync(options.pythonBin, [
@@ -117,12 +122,18 @@ function installRequirements(
       cmdOptions.push('-u', getDockerUid(bindPath));
     }
     cmdOptions.push(dockerImage);
+
     cmdOptions.push(...pipCmd);
   } else {
     cmd = pipCmd[0];
     cmdOptions = pipCmd.slice(1);
   }
+  serverless.cli.log(`command: ${cmd}`);
+  serverless.cli.log(`command options: ${cmdOptions}`);
+
   const res = spawnSync(cmd, cmdOptions, { cwd: servicePath, shell: true });
+    serverless.cli.log(`Res: ${res}`);
+
   if (res.error) {
     if (res.error.code === 'ENOENT') {
       if (options.dockerizePip) {

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -54,8 +54,6 @@ function installRequirements(
 
   pipCmd = pipCmd.concat(['||','true','||'].concat(pipCmd));
 
-  serverless.cli.log(`pip command: ${pipCmd}`);
-
   if (!options.dockerizePip) {
     // Check if pip has Debian's --system option and set it if so
     const pipTestRes = spawnSync(options.pythonBin, [
@@ -128,11 +126,8 @@ function installRequirements(
     cmd = pipCmd[0];
     cmdOptions = pipCmd.slice(1);
   }
-  serverless.cli.log(`command: ${cmd}`);
-  serverless.cli.log(`command options: ${cmdOptions}`);
 
   const res = spawnSync(cmd, cmdOptions, { cwd: servicePath, shell: true });
-    serverless.cli.log(`Res: ${res}`);
 
   if (res.error) {
     if (res.error.code === 'ENOENT') {


### PR DESCRIPTION
first off all:

a) I'm not a JS programmer, I'm very sure a better way exists to solve this issue
b) I'm not familiar with the architecture of serverless, see above

now that his out of the way.

If you want to install TA-Lib in one go, it will fail, since it depends on numpy. Even if these are specified in the order in the same requirements.txt file, TA-LIB installation will fail. Due to the dependency resolving issues in pip.

What this PR does, is simply running the install command twice and ignores the response of the first attempt.

This results in us being able to use sls to deploy ta-lib based lambda functions.