### PR TITLE
WIP: docker in docker fix

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -86,8 +86,13 @@ function installRequirements(
     }
     serverless.cli.log(`Docker Image: ${dockerImage}`);
 
-    // Prepare bind path depending on os platform
-    const bindPath = getBindPath(servicePath);
+    let bindPath;
+    if (options.dockerInDocker) {
+      bindPath = process.env['host_pwd'];
+    } else {
+      // Prepare bind path depending on os platform
+      bindPath = getBindPath(servicePath);
+    }
 
     cmdOptions = ['run', '--rm', '-v', `"${bindPath}:/var/task:z"`];
     if (options.dockerSsh) {


### PR DESCRIPTION
Please note that - I'm not a JS dev, I actually haven't studied the whole project and the fix is something I really needed to make 'it work'. I believe it's not the best solution and I'm totally open to a discussion. 

So the problem is that in CI I need to run `sls deploy` and the CI stage itself is running in a container. After some research, I found that the `bindPath` is assigned to its host `$(pwd)$` value. The problem is, the 'docker container inside the CI docker container' thinks the host is the main CI container so the path is actually wrong. So I simply shared `$(pwd)` from the original host to the CI container as a `host_pwd` env variable and let the `bindPath` to take that value in case the `dockerInDocker` option is `true`. 

In .gitlab-ci.yml

```
    - export host_pwd=$CI_PROJECT_DIR
```

and of course, the whole stage must be run in a container capable of running another container and in `config.toml` there must be docker socket specified.

and in serverless.yml

```
custom:
    pythonRequirements:
        dockerInDocker: true
        dockerizePip: true
```

What do you think?