### PR TITLE
Support serverless.yml and serverless.yaml in getBindPath()

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -70,8 +70,8 @@ function tryBindPath(bindPath, testFile) {
   try {
     const ps = dockerCommand(options);
     if (process.env.SLS_DEBUG) {
-      console.log(`Trying bindPath ${bindPath} (${options})`)
-      console.log(ps.stdout.trim());
+      this.serverless.cli.log(`Trying bindPath ${bindPath} (${options})`)
+      this.serverless.cli.log(ps.stdout.trim());
     }
     return ps.stdout.trim() === `/test/${testFile}`;
   } catch (err) {

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -49,7 +49,9 @@ function findTestFile(servicePath) {
   if (fse.pathExistsSync(path.join(servicePath, 'serverless.json'))) {
     return 'serverless.json';
   }
-  throw new Error('Unable to find serverless.yml or serverless.yaml or serverless.json for getBindPath()');
+  throw new Error(
+    'Unable to find serverless.yml or serverless.yaml or serverless.json for getBindPath()'
+  );
 }
 
 /**
@@ -70,7 +72,7 @@ function tryBindPath(bindPath, testFile) {
   try {
     const ps = dockerCommand(options);
     if (process.env.SLS_DEBUG) {
-      this.serverless.cli.log(`Trying bindPath ${bindPath} (${options})`)
+      this.serverless.cli.log(`Trying bindPath ${bindPath} (${options})`);
       this.serverless.cli.log(ps.stdout.trim());
     }
     return ps.stdout.trim() === `/test/${testFile}`;
@@ -123,7 +125,7 @@ function getBindPath(servicePath) {
   bindPaths.push(`/mnt/${drive.toLowerCase()}/${path}`);
   bindPaths.push(`/mnt/${drive.toUpperCase()}/${path}`);
   bindPaths.push(`${drive.toUpperCase()}:/${path}`);
-  
+
   const testFile = findTestFile(servicePath);
 
   for (let i = 0; i < bindPaths.length; i++) {

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -49,9 +49,7 @@ function findTestFile(servicePath) {
   if (fse.pathExistsSync(path.join(servicePath, 'serverless.json'))) {
     return 'serverless.json';
   }
-  throw new Error(
-    'Unable to find serverless.yml or serverless.yaml or serverless.json for getBindPath()'
-  );
+  throw new Error('Unable to find serverless.yml or serverless.yaml or serverless.json for getBindPath()');
 }
 
 /**
@@ -59,7 +57,7 @@ function findTestFile(servicePath) {
  * @param {string} bindPath
  * @return {boolean}
  */
-function tryBindPath(bindPath, testFile) {
+function tryBindPath(serverless, bindPath, testFile) {
   const options = [
     'run',
     '--rm',
@@ -72,8 +70,8 @@ function tryBindPath(bindPath, testFile) {
   try {
     const ps = dockerCommand(options);
     if (process.env.SLS_DEBUG) {
-      this.serverless.cli.log(`Trying bindPath ${bindPath} (${options})`);
-      this.serverless.cli.log(ps.stdout.trim());
+      serverless.cli.log(`Trying bindPath ${bindPath} (${options})`)
+      serverless.cli.log(ps.stdout.trim());
     }
     return ps.stdout.trim() === `/test/${testFile}`;
   } catch (err) {
@@ -83,10 +81,11 @@ function tryBindPath(bindPath, testFile) {
 
 /**
  * Get bind path depending on os platform
+ * @param {object} serverless
  * @param {string} servicePath
  * @return {string} The bind path.
  */
-function getBindPath(servicePath) {
+function getBindPath(serverless, servicePath) {
   // Determine bind path
   if (process.platform !== 'win32' && !isWsl) {
     return servicePath;
@@ -125,12 +124,12 @@ function getBindPath(servicePath) {
   bindPaths.push(`/mnt/${drive.toLowerCase()}/${path}`);
   bindPaths.push(`/mnt/${drive.toUpperCase()}/${path}`);
   bindPaths.push(`${drive.toUpperCase()}:/${path}`);
-
+  
   const testFile = findTestFile(servicePath);
 
   for (let i = 0; i < bindPaths.length; i++) {
     const bindPath = bindPaths[i];
-    if (tryBindPath(bindPath, testFile)) {
+    if (tryBindPath(serverless, bindPath, testFile)) {
       return bindPath;
     }
   }

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -49,7 +49,9 @@ function findTestFile(servicePath) {
   if (fse.pathExistsSync(path.join(servicePath, 'serverless.json'))) {
     return 'serverless.json';
   }
-  throw new Error('Unable to find serverless.yml or serverless.yaml or serverless.json for getBindPath()');
+  throw new Error(
+    'Unable to find serverless.yml or serverless.yaml or serverless.json for getBindPath()'
+  );
 }
 
 /**
@@ -70,7 +72,7 @@ function tryBindPath(serverless, bindPath, testFile) {
   try {
     const ps = dockerCommand(options);
     if (process.env.SLS_DEBUG) {
-      serverless.cli.log(`Trying bindPath ${bindPath} (${options})`)
+      serverless.cli.log(`Trying bindPath ${bindPath} (${options})`);
       serverless.cli.log(ps.stdout.trim());
     }
     return ps.stdout.trim() === `/test/${testFile}`;
@@ -124,7 +126,7 @@ function getBindPath(serverless, servicePath) {
   bindPaths.push(`/mnt/${drive.toLowerCase()}/${path}`);
   bindPaths.push(`/mnt/${drive.toUpperCase()}/${path}`);
   bindPaths.push(`${drive.toUpperCase()}:/${path}`);
-  
+
   const testFile = findTestFile(servicePath);
 
   for (let i = 0; i < bindPaths.length; i++) {

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -1,5 +1,7 @@
 const { spawnSync } = require('child_process');
 const isWsl = require('is-wsl');
+const fse = require('fs-extra');
+const path = require('path');
 
 /**
  * Helper function to run a docker command
@@ -33,11 +35,26 @@ function buildImage(dockerFile) {
 }
 
 /**
+ * Find a file that exists on all projects so we can test if Docker can see it too
+ * @param {string} servicePath
+ * @return {string} file name
+ */
+function findTestFile(servicePath) {
+  if (fse.pathExistsSync(path.join(servicePath, 'serverless.yml'))) {
+    return 'serverless.yml';
+  }
+  if (fse.pathExistsSync(path.join(servicePath, 'serverless.yaml'))) {
+    return 'serverless.yaml';
+  }
+  throw new Error('Unable to find serverless.yml or serverless.yaml for getBindPath()');
+}
+
+/**
  * Test bind path to make sure it's working
  * @param {string} bindPath
  * @return {boolean}
  */
-function tryBindPath(bindPath) {
+function tryBindPath(bindPath, testFile) {
   const options = [
     'run',
     '--rm',
@@ -45,11 +62,15 @@ function tryBindPath(bindPath) {
     `${bindPath}:/test`,
     'alpine',
     'ls',
-    '/test/serverless.yml'
+    `/test/${testFile}`
   ];
   try {
     const ps = dockerCommand(options);
-    return ps.stdout.trim() === '/test/serverless.yml';
+    if (process.env.SLS_DEBUG) {
+      console.log(`Trying bindPath ${bindPath} (${options})`)
+      console.log(ps.stdout.trim());
+    }
+    return ps.stdout.trim() === `/test/${testFile}`;
   } catch (err) {
     return false;
   }
@@ -94,15 +115,16 @@ function getBindPath(servicePath) {
 
   bindPaths.push(`/${drive.toLowerCase()}/${path}`); // Docker Toolbox (seems like Docker for Windows can support this too)
   bindPaths.push(`${drive.toLowerCase()}:/${path}`); // Docker for Windows
-  // other options just in case
   bindPaths.push(`/${drive.toUpperCase()}/${path}`);
   bindPaths.push(`/mnt/${drive.toLowerCase()}/${path}`);
   bindPaths.push(`/mnt/${drive.toUpperCase()}/${path}`);
   bindPaths.push(`${drive.toUpperCase()}:/${path}`);
+  
+  const testFile = findTestFile(servicePath);
 
   for (let i = 0; i < bindPaths.length; i++) {
     const bindPath = bindPaths[i];
-    if (tryBindPath(bindPath)) {
+    if (tryBindPath(bindPath, testFile)) {
       return bindPath;
     }
   }

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -115,6 +115,7 @@ function getBindPath(servicePath) {
 
   bindPaths.push(`/${drive.toLowerCase()}/${path}`); // Docker Toolbox (seems like Docker for Windows can support this too)
   bindPaths.push(`${drive.toLowerCase()}:/${path}`); // Docker for Windows
+  // other options just in case
   bindPaths.push(`/${drive.toUpperCase()}/${path}`);
   bindPaths.push(`/mnt/${drive.toLowerCase()}/${path}`);
   bindPaths.push(`/mnt/${drive.toUpperCase()}/${path}`);

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -46,7 +46,10 @@ function findTestFile(servicePath) {
   if (fse.pathExistsSync(path.join(servicePath, 'serverless.yaml'))) {
     return 'serverless.yaml';
   }
-  throw new Error('Unable to find serverless.yml or serverless.yaml for getBindPath()');
+  if (fse.pathExistsSync(path.join(servicePath, 'serverless.json'))) {
+    return 'serverless.json';
+  }
+  throw new Error('Unable to find serverless.yml or serverless.yaml or serverless.json for getBindPath()');
 }
 
 /**

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -13,10 +13,11 @@ BbPromise.promisifyAll(fse);
  * Inject requirements into packaged application.
  * @param {string} requirementsPath requirements folder path
  * @param {string} packagePath target package path
+ * @param {Object} options our options object
  * @return {Promise} the JSZip object constructed.
  */
-function injectRequirements(requirementsPath, packagePath) {
-  const noDeploy = new Set(this.options.noDeploy || []);
+function injectRequirements(requirementsPath, packagePath, options) {
+  const noDeploy = new Set(options.noDeploy || []);
 
   return fse
     .readFileAsync(packagePath)
@@ -106,13 +107,15 @@ function injectAllRequirements(funcArtifact) {
           ? func
           : injectRequirements(
               path.join('.serverless', func.module, 'requirements'),
-              func.package.artifact
+              func.package.artifact,
+              this.options
             );
-      }, this);
+      });
   } else if (!this.options.zip) {
     return injectRequirements(
       path.join('.serverless', 'requirements'),
-      this.serverless.service.package.artifact || funcArtifact
+      this.serverless.service.package.artifact || funcArtifact,
+      this.options
     );
   }
 }

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -105,9 +105,9 @@ function injectAllRequirements(funcArtifact) {
         return this.options.zip
           ? func
           : injectRequirements(
-          path.join('.serverless', func.module, 'requirements'),
-          func.package.artifact
-      );
+              path.join('.serverless', func.module, 'requirements'),
+              func.package.artifact
+            );
       }, this);
   } else if (!this.options.zip) {
     return injectRequirements(

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -13,11 +13,10 @@ BbPromise.promisifyAll(fse);
  * Inject requirements into packaged application.
  * @param {string} requirementsPath requirements folder path
  * @param {string} packagePath target package path
- * @param {Object} options our options object
  * @return {Promise} the JSZip object constructed.
  */
-function injectRequirements(requirementsPath, packagePath, options) {
-  const noDeploy = new Set(options.noDeploy || []);
+function injectRequirements(requirementsPath, packagePath) {
+  const noDeploy = new Set(this.options.noDeploy || []);
 
   return fse
     .readFileAsync(packagePath)
@@ -106,16 +105,14 @@ function injectAllRequirements(funcArtifact) {
         return this.options.zip
           ? func
           : injectRequirements(
-              path.join('.serverless', func.module, 'requirements'),
-              func.package.artifact,
-              this.options
-            );
-      });
+          path.join('.serverless', func.module, 'requirements'),
+          func.package.artifact
+      );
+      }, this);
   } else if (!this.options.zip) {
     return injectRequirements(
       path.join('.serverless', 'requirements'),
-      this.serverless.service.package.artifact || funcArtifact,
-      this.options
+      this.serverless.service.package.artifact || funcArtifact
     );
   }
 }

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -11,49 +11,43 @@ const { getSlimPackageCommands } = require('./slim');
  * Install requirements described in requirementsPath to targetFolder
  * @param {string} requirementsPath
  * @param {string} targetFolder
- * @param {Object} serverless
- * @param {string} servicePath
- * @param {Object} options
  * @return {undefined}
  */
 function installRequirements(
   requirementsPath,
-  targetFolder,
-  serverless,
-  servicePath,
-  options
+  targetFolder
 ) {
   // Create target folder if it does not exist
   const targetRequirementsFolder = path.join(targetFolder, 'requirements');
   fse.ensureDirSync(targetRequirementsFolder);
 
   const dotSlsReqs = path.join(targetFolder, 'requirements.txt');
-  if (options.usePipenv && fse.existsSync(path.join(servicePath, 'Pipfile'))) {
-    generateRequirementsFile(dotSlsReqs, dotSlsReqs, options);
+  if (this.options.usePipenv && fse.existsSync(path.join(this.servicePath, 'Pipfile'))) {
+    generateRequirementsFile(dotSlsReqs, dotSlsReqs);
   } else {
-    generateRequirementsFile(requirementsPath, dotSlsReqs, options);
+    generateRequirementsFile(requirementsPath, dotSlsReqs);
   }
 
-  serverless.cli.log(
+  this.serverless.cli.log(
     `Installing requirements of ${requirementsPath} in ${targetFolder}...`
   );
 
   let cmd;
   let cmdOptions;
   let pipCmd = [
-    options.pythonBin,
+    this.options.pythonBin,
     '-m',
     'pip',
     'install',
     '-t',
-    dockerPathForWin(options, targetRequirementsFolder),
+    dockerPathForWin(targetRequirementsFolder),
     '-r',
-    dockerPathForWin(options, dotSlsReqs),
-    ...options.pipCmdExtraArgs
+    dockerPathForWin(dotSlsReqs),
+    ...this.options.pipCmdExtraArgs
   ];
-  if (!options.dockerizePip) {
+  if (!this.options.dockerizePip) {
     // Check if pip has Debian's --system option and set it if so
-    const pipTestRes = spawnSync(options.pythonBin, [
+    const pipTestRes = spawnSync(this.options.pythonBin, [
       '-m',
       'pip',
       'help',
@@ -62,7 +56,7 @@ function installRequirements(
     if (pipTestRes.error) {
       if (pipTestRes.error.code === 'ENOENT') {
         throw new Error(
-          `${options.pythonBin} not found! ` + 'Try the pythonBin option.'
+          `${this.options.pythonBin} not found! ` + 'Try the pythonBin option.'
         );
       }
       throw pipTestRes.error;
@@ -71,26 +65,26 @@ function installRequirements(
       pipCmd.push('--system');
     }
   }
-  if (options.dockerizePip) {
+  if (this.options.dockerizePip) {
     cmd = 'docker';
 
     // Build docker image if required
     let dockerImage;
-    if (options.dockerFile) {
-      serverless.cli.log(
-        `Building custom docker image from ${options.dockerFile}...`
+    if (this.options.dockerFile) {
+      this.serverless.cli.log(
+        `Building custom docker image from ${this.options.dockerFile}...`
       );
-      dockerImage = buildImage(options.dockerFile);
+      dockerImage = buildImage(this.options.dockerFile);
     } else {
-      dockerImage = options.dockerImage;
+      dockerImage = this.options.dockerImage;
     }
-    serverless.cli.log(`Docker Image: ${dockerImage}`);
+    this.serverless.cli.log(`Docker Image: ${dockerImage}`);
 
     // Prepare bind path depending on os platform
-    const bindPath = getBindPath(servicePath);
+    const bindPath = getBindPath(this.servicePath);
 
     cmdOptions = ['run', '--rm', '-v', `"${bindPath}:/var/task:z"`];
-    if (options.dockerSsh) {
+    if (this.options.dockerSsh) {
       // Mount necessary ssh files to work with private repos
       cmdOptions.push(
         '-v',
@@ -124,20 +118,20 @@ function installRequirements(
   }
 
   // If enabled slimming, strip out the caches, tests and dist-infos
-  if (options.slim === true || options.slim === 'true') {
-    const preparedPath = dockerPathForWin(options, targetRequirementsFolder);
-    const slimCmd = getSlimPackageCommands(options, preparedPath);
+  if (this.options.slim === true || this.options.slim === 'true') {
+    const preparedPath = dockerPathForWin(targetRequirementsFolder);
+    const slimCmd = getSlimPackageCommands(preparedPath);
     cmdOptions.push(...slimCmd);
   }
 
-  const res = spawnSync(cmd, cmdOptions, { cwd: servicePath, shell: true });
+  const res = spawnSync(cmd, cmdOptions, { cwd: this.servicePath, shell: true });
   if (res.error) {
     if (res.error.code === 'ENOENT') {
-      if (options.dockerizePip) {
+      if (this.options.dockerizePip) {
         throw new Error('docker not found! Please install it.');
       }
       throw new Error(
-        `${options.pythonBin} not found! Try the pythonBin option.`
+        `${this.options.pythonBin} not found! Try the pythonBin option.`
       );
     }
     throw res.error;
@@ -149,12 +143,11 @@ function installRequirements(
 
 /**
  * convert path from Windows style to Linux style, if needed
- * @param {Object} options
  * @param {string} path
  * @return {string}
  */
-function dockerPathForWin(options, path) {
-  if (process.platform === 'win32' && options.dockerizePip) {
+function dockerPathForWin(path) {
+  if (process.platform === 'win32' && this.options.dockerizePip) {
     return path.replace(/\\/g, '/');
   }
   return path;
@@ -163,10 +156,9 @@ function dockerPathForWin(options, path) {
 /** create a filtered requirements.txt without anything from noDeploy
  * @param {string} source requirements
  * @param {string} target requirements where results are written
- * @param {Object} options
  */
-function generateRequirementsFile(source, target, options) {
-  const noDeploy = new Set(options.noDeploy || []);
+function generateRequirementsFile(source, target) {
+  const noDeploy = new Set(this.options.noDeploy || []);
   const requirements = fse
     .readFileSync(source, { encoding: 'utf-8' })
     .split(/\r?\n/);
@@ -180,14 +172,13 @@ function generateRequirementsFile(source, target, options) {
  * Copy everything from vendorFolder to targetFolder
  * @param {string} vendorFolder
  * @param {string} targetFolder
- * @param {Object} serverless
  * @return {undefined}
  */
-function copyVendors(vendorFolder, targetFolder, serverless) {
+function copyVendors(vendorFolder, targetFolder) {
   // Create target folder if it does not exist
   const targetRequirementsFolder = path.join(targetFolder, 'requirements');
 
-  serverless.cli.log(
+  this.serverless.cli.log(
     `Copying vendor libraries from ${vendorFolder} to ${targetRequirementsFolder}...`
   );
 
@@ -222,33 +213,26 @@ function installAllRequirements() {
         if (!doneModules.includes(f.module)) {
           installRequirements(
             path.join(f.module, this.options.fileName),
-            path.join('.serverless', f.module),
-            this.serverless,
-            this.servicePath,
-            this.options
+            path.join('.serverless', f.module)
           );
           if (f.vendor) {
             // copy vendor libraries to requirements folder
             copyVendors(
               f.vendor,
-              path.join('.serverless', f.module),
-              this.serverless
+              path.join('.serverless', f.module)
             );
           }
           doneModules.push(f.module);
         }
-      });
+      }, this);
   } else {
     installRequirements(
       this.options.fileName,
-      '.serverless',
-      this.serverless,
-      this.servicePath,
-      this.options
+      '.serverless'
     );
     if (this.options.vendor) {
       // copy vendor libraries to requirements folder
-      copyVendors(this.options.vendor, '.serverless', this.serverless);
+      copyVendors(this.options.vendor, '.serverless');
     }
   }
 }

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -13,16 +13,16 @@ const { getSlimPackageCommands } = require('./slim');
  * @param {string} targetFolder
  * @return {undefined}
  */
-function installRequirements(
-  requirementsPath,
-  targetFolder
-) {
+function installRequirements(requirementsPath, targetFolder) {
   // Create target folder if it does not exist
   const targetRequirementsFolder = path.join(targetFolder, 'requirements');
   fse.ensureDirSync(targetRequirementsFolder);
 
   const dotSlsReqs = path.join(targetFolder, 'requirements.txt');
-  if (this.options.usePipenv && fse.existsSync(path.join(this.servicePath, 'Pipfile'))) {
+  if (
+    this.options.usePipenv &&
+    fse.existsSync(path.join(this.servicePath, 'Pipfile'))
+  ) {
     generateRequirementsFile(dotSlsReqs, dotSlsReqs);
   } else {
     generateRequirementsFile(requirementsPath, dotSlsReqs);
@@ -124,7 +124,10 @@ function installRequirements(
     cmdOptions.push(...slimCmd);
   }
 
-  const res = spawnSync(cmd, cmdOptions, { cwd: this.servicePath, shell: true });
+  const res = spawnSync(cmd, cmdOptions, {
+    cwd: this.servicePath,
+    shell: true
+  });
   if (res.error) {
     if (res.error.code === 'ENOENT') {
       if (this.options.dockerizePip) {
@@ -217,19 +220,13 @@ function installAllRequirements() {
           );
           if (f.vendor) {
             // copy vendor libraries to requirements folder
-            copyVendors(
-              f.vendor,
-              path.join('.serverless', f.module)
-            );
+            copyVendors(f.vendor, path.join('.serverless', f.module));
           }
           doneModules.push(f.module);
         }
       }, this);
   } else {
-    installRequirements(
-      this.options.fileName,
-      '.serverless'
-    );
+    installRequirements(this.options.fileName, '.serverless');
     if (this.options.vendor) {
       // copy vendor libraries to requirements folder
       copyVendors(this.options.vendor, '.serverless');

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -11,43 +11,49 @@ const { getSlimPackageCommands } = require('./slim');
  * Install requirements described in requirementsPath to targetFolder
  * @param {string} requirementsPath
  * @param {string} targetFolder
+ * @param {Object} serverless
+ * @param {string} servicePath
+ * @param {Object} options
  * @return {undefined}
  */
-function installRequirements(requirementsPath, targetFolder) {
+function installRequirements(
+  requirementsPath,
+  targetFolder,
+  serverless,
+  servicePath,
+  options
+) {
   // Create target folder if it does not exist
   const targetRequirementsFolder = path.join(targetFolder, 'requirements');
   fse.ensureDirSync(targetRequirementsFolder);
 
   const dotSlsReqs = path.join(targetFolder, 'requirements.txt');
-  if (
-    this.options.usePipenv &&
-    fse.existsSync(path.join(this.servicePath, 'Pipfile'))
-  ) {
-    generateRequirementsFile(dotSlsReqs, dotSlsReqs);
+  if (options.usePipenv && fse.existsSync(path.join(servicePath, 'Pipfile'))) {
+    generateRequirementsFile(dotSlsReqs, dotSlsReqs, options);
   } else {
-    generateRequirementsFile(requirementsPath, dotSlsReqs);
+    generateRequirementsFile(requirementsPath, dotSlsReqs, options);
   }
 
-  this.serverless.cli.log(
+  serverless.cli.log(
     `Installing requirements of ${requirementsPath} in ${targetFolder}...`
   );
 
   let cmd;
   let cmdOptions;
   let pipCmd = [
-    this.options.pythonBin,
+    options.pythonBin,
     '-m',
     'pip',
     'install',
     '-t',
-    dockerPathForWin(targetRequirementsFolder),
+    dockerPathForWin(options, targetRequirementsFolder),
     '-r',
-    dockerPathForWin(dotSlsReqs),
-    ...this.options.pipCmdExtraArgs
+    dockerPathForWin(options, dotSlsReqs),
+    ...options.pipCmdExtraArgs
   ];
-  if (!this.options.dockerizePip) {
+  if (!options.dockerizePip) {
     // Check if pip has Debian's --system option and set it if so
-    const pipTestRes = spawnSync(this.options.pythonBin, [
+    const pipTestRes = spawnSync(options.pythonBin, [
       '-m',
       'pip',
       'help',
@@ -56,7 +62,7 @@ function installRequirements(requirementsPath, targetFolder) {
     if (pipTestRes.error) {
       if (pipTestRes.error.code === 'ENOENT') {
         throw new Error(
-          `${this.options.pythonBin} not found! ` + 'Try the pythonBin option.'
+          `${options.pythonBin} not found! ` + 'Try the pythonBin option.'
         );
       }
       throw pipTestRes.error;
@@ -65,26 +71,26 @@ function installRequirements(requirementsPath, targetFolder) {
       pipCmd.push('--system');
     }
   }
-  if (this.options.dockerizePip) {
+  if (options.dockerizePip) {
     cmd = 'docker';
 
     // Build docker image if required
     let dockerImage;
-    if (this.options.dockerFile) {
-      this.serverless.cli.log(
-        `Building custom docker image from ${this.options.dockerFile}...`
+    if (options.dockerFile) {
+      serverless.cli.log(
+        `Building custom docker image from ${options.dockerFile}...`
       );
-      dockerImage = buildImage(this.options.dockerFile);
+      dockerImage = buildImage(options.dockerFile);
     } else {
-      dockerImage = this.options.dockerImage;
+      dockerImage = options.dockerImage;
     }
-    this.serverless.cli.log(`Docker Image: ${dockerImage}`);
+    serverless.cli.log(`Docker Image: ${dockerImage}`);
 
     // Prepare bind path depending on os platform
-    const bindPath = getBindPath(this.servicePath);
+    const bindPath = getBindPath(serverless, servicePath);
 
     cmdOptions = ['run', '--rm', '-v', `"${bindPath}:/var/task:z"`];
-    if (this.options.dockerSsh) {
+    if (options.dockerSsh) {
       // Mount necessary ssh files to work with private repos
       cmdOptions.push(
         '-v',
@@ -118,23 +124,20 @@ function installRequirements(requirementsPath, targetFolder) {
   }
 
   // If enabled slimming, strip out the caches, tests and dist-infos
-  if (this.options.slim === true || this.options.slim === 'true') {
-    const preparedPath = dockerPathForWin(targetRequirementsFolder);
-    const slimCmd = getSlimPackageCommands(preparedPath);
+  if (options.slim === true || options.slim === 'true') {
+    const preparedPath = dockerPathForWin(options, targetRequirementsFolder);
+    const slimCmd = getSlimPackageCommands(options, preparedPath);
     cmdOptions.push(...slimCmd);
   }
 
-  const res = spawnSync(cmd, cmdOptions, {
-    cwd: this.servicePath,
-    shell: true
-  });
+  const res = spawnSync(cmd, cmdOptions, { cwd: servicePath, shell: true });
   if (res.error) {
     if (res.error.code === 'ENOENT') {
-      if (this.options.dockerizePip) {
+      if (options.dockerizePip) {
         throw new Error('docker not found! Please install it.');
       }
       throw new Error(
-        `${this.options.pythonBin} not found! Try the pythonBin option.`
+        `${options.pythonBin} not found! Try the pythonBin option.`
       );
     }
     throw res.error;
@@ -146,11 +149,12 @@ function installRequirements(requirementsPath, targetFolder) {
 
 /**
  * convert path from Windows style to Linux style, if needed
+ * @param {Object} options
  * @param {string} path
  * @return {string}
  */
-function dockerPathForWin(path) {
-  if (process.platform === 'win32' && this.options.dockerizePip) {
+function dockerPathForWin(options, path) {
+  if (process.platform === 'win32' && options.dockerizePip) {
     return path.replace(/\\/g, '/');
   }
   return path;
@@ -159,9 +163,10 @@ function dockerPathForWin(path) {
 /** create a filtered requirements.txt without anything from noDeploy
  * @param {string} source requirements
  * @param {string} target requirements where results are written
+ * @param {Object} options
  */
-function generateRequirementsFile(source, target) {
-  const noDeploy = new Set(this.options.noDeploy || []);
+function generateRequirementsFile(source, target, options) {
+  const noDeploy = new Set(options.noDeploy || []);
   const requirements = fse
     .readFileSync(source, { encoding: 'utf-8' })
     .split(/\r?\n/);
@@ -175,13 +180,14 @@ function generateRequirementsFile(source, target) {
  * Copy everything from vendorFolder to targetFolder
  * @param {string} vendorFolder
  * @param {string} targetFolder
+ * @param {Object} serverless
  * @return {undefined}
  */
-function copyVendors(vendorFolder, targetFolder) {
+function copyVendors(vendorFolder, targetFolder, serverless) {
   // Create target folder if it does not exist
   const targetRequirementsFolder = path.join(targetFolder, 'requirements');
 
-  this.serverless.cli.log(
+  serverless.cli.log(
     `Copying vendor libraries from ${vendorFolder} to ${targetRequirementsFolder}...`
   );
 
@@ -216,20 +222,33 @@ function installAllRequirements() {
         if (!doneModules.includes(f.module)) {
           installRequirements(
             path.join(f.module, this.options.fileName),
-            path.join('.serverless', f.module)
+            path.join('.serverless', f.module),
+            this.serverless,
+            this.servicePath,
+            this.options
           );
           if (f.vendor) {
             // copy vendor libraries to requirements folder
-            copyVendors(f.vendor, path.join('.serverless', f.module));
+            copyVendors(
+              f.vendor,
+              path.join('.serverless', f.module),
+              this.serverless
+            );
           }
           doneModules.push(f.module);
         }
-      }, this);
+      });
   } else {
-    installRequirements(this.options.fileName, '.serverless');
+    installRequirements(
+      this.options.fileName,
+      '.serverless',
+      this.serverless,
+      this.servicePath,
+      this.options
+    );
     if (this.options.vendor) {
       // copy vendor libraries to requirements folder
-      copyVendors(this.options.vendor, '.serverless');
+      copyVendors(this.options.vendor, '.serverless', this.serverless);
     }
   }
 }


### PR DESCRIPTION
This should fix the issue reported by @mrpgraae in #210.
I've also added support for `SLS_DEBUG` so we can more easily get some information on future errors.