### PR TITLE
Properly supporting `sls deploy function` command and zip option

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,10 +85,10 @@ class ServerlessPythonRequirements {
   }
 
   get targetFuncs() {
-    let inputOpt = this.serverless.processedInput.options
+    let inputOpt = this.serverless.processedInput.options;
     return inputOpt.function
       ? [inputOpt.functionObj]
-      : values(this.serverless.service.functions)
+      : values(this.serverless.service.functions);
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 
 const BbPromise = require('bluebird');
 const fse = require('fs-extra');
+const values = require('lodash.values');
 const {
   addVendorHelper,
   removeVendorHelper,
@@ -81,6 +82,13 @@ class ServerlessPythonRequirements {
       options.dockerImage = options.dockerImage || defaultImage;
     }
     return options;
+  }
+
+  get targetFuncs() {
+    let inputOpt = this.serverless.processedInput.options
+    return inputOpt.function
+      ? [inputOpt.functionObj]
+      : values(this.serverless.service.functions)
   }
 
   /**

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -1,7 +1,6 @@
 const BbPromise = require('bluebird');
 const fse = require('fs-extra');
 const path = require('path');
-const values = require('lodash.values');
 
 BbPromise.promisifyAll(fse);
 
@@ -13,7 +12,7 @@ function cleanup() {
   const artifacts = ['.requirements'];
   if (this.options.zip) {
     if (this.serverless.service.package.individually) {
-      values(this.serverless.service.functions).forEach(f => {
+      this.targetFuncs.forEach(f => {
         artifacts.push(path.join(f.module, '.requirements.zip'));
         artifacts.push(path.join(f.module, 'unzip_requirements.py'));
       });

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -106,10 +106,10 @@ function injectAllRequirements(funcArtifact) {
         return this.options.zip
           ? func
           : injectRequirements(
-            path.join('.serverless', func.module, 'requirements'),
-            func.package.artifact,
-            this.options
-          )
+              path.join('.serverless', func.module, 'requirements'),
+              func.package.artifact,
+              this.options
+            );
       });
   } else if (!this.options.zip) {
     return injectRequirements(

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -74,10 +74,6 @@ function moveModuleUp(source, target, module) {
 function injectAllRequirements(funcArtifact) {
   this.serverless.cli.log('Injecting required Python packages to package...');
 
-  if (this.options.zip) {
-    return;
-  }
-
   if (this.serverless.service.package.individually) {
     return BbPromise.resolve(this.targetFuncs)
       .filter(func =>
@@ -106,14 +102,16 @@ function injectAllRequirements(funcArtifact) {
           return func;
         }
       })
-      .map(func =>
-        injectRequirements(
-          path.join('.serverless', func.module, 'requirements'),
-          func.package.artifact,
-          this.options
-        )
-      );
-  } else {
+      .map(func => {
+        return this.options.zip
+          ? func
+          : injectRequirements(
+            path.join('.serverless', func.module, 'requirements'),
+            func.package.artifact,
+            this.options
+          )
+      });
+  } else if (!this.options.zip) {
     return injectRequirements(
       path.join('.serverless', 'requirements'),
       this.serverless.service.package.artifact || funcArtifact,

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -4,7 +4,6 @@ const glob = require('glob-all');
 const get = require('lodash.get');
 const set = require('lodash.set');
 const path = require('path');
-const values = require('lodash.values');
 const JSZip = require('jszip');
 const { writeZip, zipFile } = require('./zipTree');
 
@@ -80,7 +79,7 @@ function injectAllRequirements(funcArtifact) {
   }
 
   if (this.serverless.service.package.individually) {
-    return BbPromise.resolve(values(this.serverless.service.functions))
+    return BbPromise.resolve(this.targetFuncs)
       .filter(func =>
         (func.runtime || this.serverless.service.provider.runtime).match(
           /^python.*/

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -4,7 +4,6 @@ const path = require('path');
 const get = require('lodash.get');
 const set = require('lodash.set');
 const { spawnSync } = require('child_process');
-const values = require('lodash.values');
 const { buildImage, getBindPath, getDockerUid } = require('./docker');
 const { getSlimPackageCommands } = require('./slim');
 
@@ -210,7 +209,7 @@ function installAllRequirements() {
   fse.ensureDirSync(path.join(this.servicePath, '.serverless'));
   if (this.serverless.service.package.individually) {
     let doneModules = [];
-    values(this.serverless.service.functions)
+    this.targetFuncs
       .filter(func =>
         (func.runtime || this.serverless.service.provider.runtime).match(
           /^python.*/

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -2,7 +2,6 @@ const fse = require('fs-extra');
 const path = require('path');
 const get = require('lodash.get');
 const set = require('lodash.set');
-const values = require('lodash.values');
 const uniqBy = require('lodash.uniqby');
 const BbPromise = require('bluebird');
 const JSZip = require('jszip');
@@ -17,7 +16,7 @@ BbPromise.promisifyAll(fse);
 function addVendorHelper() {
   if (this.options.zip) {
     if (this.serverless.service.package.individually) {
-      return BbPromise.resolve(values(this.serverless.service.functions))
+      return BbPromise.resolve(this.targetFuncs)
         .map(f => {
           if (!get(f, 'package.include')) {
             set(f, ['package', 'include'], []);
@@ -63,7 +62,7 @@ function addVendorHelper() {
 function removeVendorHelper() {
   if (this.options.zip && this.options.cleanupZipHelper) {
     if (this.serverless.service.package.individually) {
-      return BbPromise.resolve(values(this.serverless.service.functions))
+      return BbPromise.resolve(this.targetFuncs)
         .map(f => {
           if (!get(f, 'module')) {
             set(f, ['module'], '.');
@@ -95,7 +94,7 @@ function removeVendorHelper() {
 function packRequirements() {
   if (this.options.zip) {
     if (this.serverless.service.package.individually) {
-      return BbPromise.resolve(values(this.serverless.service.functions))
+      return BbPromise.resolve(this.targetFuncs)
         .map(f => {
           if (!get(f, 'module')) {
             set(f, ['module'], '.');


### PR DESCRIPTION
This PR fixes two issues I encountered while using `individually: true` option.

**1. Should package only the given function when invoked by `sls deploy function --function $FN_NAME`**

Suppose using `individually: true`. If you'd like to deploy a single function using `sls deploy function` command you'd expect the plugin to package only the module that contains the function specified. The current implementation, however, runs packaging for every module in `serverless.yml` definition, taking as much time as deploying all applications just to deploy a single function.

I simply added explicit `targetFuncs` property to filter target function if any specified in command line option.

**2. `moveModulesUp` should be called regardless of `zip` option**

When `individually: true`, each deployed function has its module as a root directory. This is achieved by calling `moveModulesUp`, but this method call is ignored when `zip` option is enabled. This certainly seems to be a wrong implementation (causing #203). If `injectModule` is ensured not to be called when `zip: true`, it is safe to call `moveModulesUp` whether `zip` is enabled or not.

The fix seems to work well on my case, but it lacks new unit tests (I couldn't figure out how to compose one.) If you let me known how to add a test, I'll update the PR as soon as I can.