### PR TITLE
Adding -f and -i to requirements.txt options ignore list before sorting

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -269,7 +269,9 @@ function dockerPathForWin(options, path) {
  *  then remove all comments and empty lines, and sort the list which
  *  assist with matching the static cache.  The sorting will skip any
  *  lines starting with -- as those are typically ordered at the
- *  start of a file ( eg: --index-url / --extra-index-url )
+ *  start of a file ( eg: --index-url / --extra-index-url ) or any
+ *  lines that start with -f or -i,  Please see:
+ * https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
  * @param {string} source requirements
  * @param {string} target requirements where results are written
  * @param {Object} options
@@ -285,7 +287,11 @@ function generateRequirementsFile(source, target, options) {
     if (req.startsWith('#')) {
       // Skip comments
       return false;
-    } else if (req.startsWith('--')) {
+    } else if (
+      req.startsWith('--') ||
+      req.startsWith('-f') ||
+      req.startsWith('-i')
+    ) {
       // If we have options (prefixed with --) keep them for later
       prepend.push(req);
       return false;
@@ -295,7 +301,9 @@ function generateRequirementsFile(source, target, options) {
   filteredRequirements.sort(); // Sort remaining alphabetically
   // Then prepend any options from above in the same order
   for (let item of prepend.reverse()) {
-    filteredRequirements.unshift(item);
+    if (item && item.length > 0) {
+      filteredRequirements.unshift(item);
+    }
   }
   fse.writeFileSync(target, filteredRequirements.join('\n'));
 }


### PR DESCRIPTION
Fixes: #236 (again, properly)

Problem: requirements.txt options which must be in the proper order at the start of the file were being sorted.  This properly skips sorting them and keeps them in order they were.