### PR TITLE
Update tests

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -289,6 +289,8 @@ function generateRequirementsFile(source, target, options) {
       // If we have options (prefixed with --) keep them for later
       prepend.push(req);
       return false;
+    } else if (req === '') {
+      return false;
     }
     return !noDeploy.has(req.split(/[=<> \t]/)[0].trim());
   });
@@ -297,7 +299,7 @@ function generateRequirementsFile(source, target, options) {
   for (let item of prepend.reverse()) {
     filteredRequirements.unshift(item);
   }
-  fse.writeFileSync(target, filteredRequirements.join('\n'));
+  fse.writeFileSync(target, filteredRequirements.join('\n') + '\n');
 }
 
 /**

--- a/test.bats
+++ b/test.bats
@@ -191,7 +191,7 @@ teardown() {
     perl -p -i'.bak' -e 's/(pythonRequirements:$)/\1\n    useDownloadCache: true\n    useStaticCache: true/' serverless.yml
     sls package
     USR_CACHE_DIR=`node -e 'console.log(require("./node_modules/serverless-python-requirements/lib/shared").getUserCachePath())'`
-    CACHE_FOLDER_HASH=$(md5sum .serverless/requirements.txt | cut -d' ' -f1)_slspyc
+    CACHE_FOLDER_HASH=$(md5sum <(grep -v boto3 requirements.txt|sort) | cut -d' ' -f1)_slspyc
     ls $USR_CACHE_DIR/$CACHE_FOLDER_HASH/flask
     ls $USR_CACHE_DIR/downloadCacheslspyc/http
 }
@@ -204,7 +204,7 @@ teardown() {
     perl -p -i'.bak' -e 's/(pythonRequirements:$)/\1\n    useDownloadCache: true\n    useStaticCache: true/' serverless.yml
     sls --dockerizePip=true package
     USR_CACHE_DIR=`node -e 'console.log(require("../../lib/shared").getUserCachePath())'`
-    CACHE_FOLDER_HASH=$(md5sum .serverless/requirements.txt | cut -d' ' -f1)_slspyc
+    CACHE_FOLDER_HASH=$(md5sum <(grep -v boto3 requirements.txt|sort) | cut -d' ' -f1)_slspyc
     ls $USR_CACHE_DIR/$CACHE_FOLDER_HASH/flask
     ls $USR_CACHE_DIR/downloadCacheslspyc/http
 }
@@ -215,7 +215,7 @@ teardown() {
     perl -p -i'.bak' -e 's/(pythonRequirements:$)/\1\n    useStaticCache: true/' serverless.yml
     sls package
     USR_CACHE_DIR=`node -e 'console.log(require("../../lib/shared").getUserCachePath())'`
-    CACHE_FOLDER_HASH=$(md5sum .serverless/requirements.txt | cut -d' ' -f1)_slspyc
+    CACHE_FOLDER_HASH=$(md5sum <(grep -v boto3 requirements.txt|sort) | cut -d' ' -f1)_slspyc
     ls $USR_CACHE_DIR/$CACHE_FOLDER_HASH/flask
     ls $USR_CACHE_DIR/$CACHE_FOLDER_HASH/.completed_requirements
 }
@@ -226,7 +226,7 @@ teardown() {
     perl -p -i'.bak' -e 's/(pythonRequirements:$)/\1\n    useStaticCache: true\n    cacheLocation: .requirements-cache/' serverless.yml
     sls package
     USR_CACHE_DIR=`node -e 'console.log(require("../../lib/shared").getUserCachePath())'`
-    CACHE_FOLDER_HASH=$(md5sum .serverless/requirements.txt | cut -d' ' -f1)_slspyc
+    CACHE_FOLDER_HASH=$(md5sum <(grep -v boto3 requirements.txt|sort) | cut -d' ' -f1)_slspyc
     ls .requirements-cache/$CACHE_FOLDER_HASH/flask
     ls .requirements-cache/$CACHE_FOLDER_HASH/.completed_requirements
 }
@@ -238,7 +238,7 @@ teardown() {
     sls package
     cp .serverless/sls-py-req-test.zip ./puck
     USR_CACHE_DIR=`node -e 'console.log(require("../../lib/shared").getUserCachePath())'`
-    CACHE_FOLDER_HASH=$(md5sum .serverless/requirements.txt | cut -d' ' -f1)_slspyc
+    CACHE_FOLDER_HASH=$(md5sum <(grep -v boto3 requirements.txt|sort) | cut -d' ' -f1)_slspyc
     echo "injected new file into static cache folder" > $USR_CACHE_DIR/$CACHE_FOLDER_HASH/injected_file_is_bad_form
     sls package
     [ `wc -c ./.serverless/sls-py-req-test.zip | awk '{ print $1 }'` -gt `wc -c ./puck | awk '{ print $1 }'` ]
@@ -251,7 +251,7 @@ teardown() {
     ! uname -sm|grep Linux || groups|grep docker || id -u|egrep '^0$' || skip "can't dockerize on linux if not root & not in docker group"
     perl -p -i'.bak' -e 's/(pythonRequirements:$)/\1\n    useStaticCache: true/' serverless.yml
     sls --dockerizePip=true --slim=true package
-    CACHE_FOLDER_HASH=$(md5sum .serverless/requirements.txt | cut -d' ' -f1)_slspyc
+    CACHE_FOLDER_HASH=$(md5sum <(grep -v boto3 requirements.txt|sort) | cut -d' ' -f1)_slspyc
     ls $USR_CACHE_DIR/$CACHE_FOLDER_HASH/flask
     unzip .serverless/sls-py-req-test.zip -d puck
     test $(find puck -name "*.pyc" | wc -l) -eq 0

--- a/tests/base/package.json
+++ b/tests/base/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "serverless-python-requirements": "file:serverless-python-requirements-4.1.1.tgz"
+    "serverless-python-requirements": "file:serverless-python-requirements-4.2.1.tgz"
   }
 }

--- a/tests/individually/package.json
+++ b/tests/individually/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "serverless-python-requirements": "file:serverless-python-requirements-4.1.1.tgz"
+    "serverless-python-requirements": "file:serverless-python-requirements-4.2.1.tgz"
   }
 }

--- a/tests/pipenv/package.json
+++ b/tests/pipenv/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "serverless-python-requirements": "file:serverless-python-requirements-4.1.1.tgz"
+    "serverless-python-requirements": "file:serverless-python-requirements-4.2.1.tgz"
   }
 }


### PR DESCRIPTION
 * Don't skip non-docker tests when docker isn't present
 * Don't hard code a static cache md5sum


@andrewfarley, I noticed that tests were failing on #238 and got the same errors locally on `master`. Do you think it's reasonable to compute the md5sum this way? I don't like hard coding the hash. But, I understand that this makes the test verify less of the process. Best would probably be to externally replicate what `genrerateRequirementsFile` does to create a new file and md5sum that instead of `.serverless/requirements.txt`