### PR TITLE
Bugfig, allowing all paths to have spaces

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -14,6 +14,10 @@ const {
   getUserCachePath
 } = require('./shared');
 
+function quote_single(quoteme) {
+  return quote([quoteme]);
+}
+
 /**
  * Just generate the requirements file in the .serverless folder
  * @param {string} requirementsPath
@@ -100,7 +104,7 @@ function installRequirements(targetFolder, serverless, options) {
       );
       serverless.cli.log(`Using download cache directory ${downloadCacheDir}`);
       fse.ensureDirSync(downloadCacheDir);
-      pipCmd.push('--cache-dir', downloadCacheDir);
+      pipCmd.push('--cache-dir', quote_single(downloadCacheDir));
     }
 
     // Check if pip has Debian's --system option and set it if so
@@ -145,18 +149,23 @@ function installRequirements(targetFolder, serverless, options) {
     // Prepare bind path depending on os platform
     const bindPath = getBindPath(serverless, targetFolder);
 
-    cmdOptions = ['run', '--rm', '-v', `"${bindPath}:/var/task:z"`];
+    cmdOptions = ['run', '--rm', '-v', quote_single(`${bindPath}:/var/task:z`)];
     if (options.dockerSsh) {
       // Mount necessary ssh files to work with private repos
       cmdOptions.push(
         '-v',
-        `"${process.env.HOME}/.ssh/id_rsa:/root/.ssh/id_rsa:z"`
+        quote_single(`${process.env.HOME}/.ssh/id_rsa:/root/.ssh/id_rsa:z`)
       );
       cmdOptions.push(
         '-v',
-        `"${process.env.HOME}/.ssh/known_hosts:/root/.ssh/known_hosts:z"`
+        quote_single(
+          `${process.env.HOME}/.ssh/known_hosts:/root/.ssh/known_hosts:z`
+        )
       );
-      cmdOptions.push('-v', `"${process.env.SSH_AUTH_SOCK}:/tmp/ssh_sock:z"`);
+      cmdOptions.push(
+        '-v',
+        quote_single(`${process.env.SSH_AUTH_SOCK}:/tmp/ssh_sock:z`)
+      );
       cmdOptions.push('-e', 'SSH_AUTH_SOCK=/tmp/ssh_sock');
     }
 
@@ -177,8 +186,11 @@ function installRequirements(targetFolder, serverless, options) {
       );
       const windowsized = getBindPath(serverless, downloadCacheDir);
       // And now push it to a volume mount and to pip...
-      cmdOptions.push('-v', `"${windowsized}:${dockerDownloadCacheDir}:z"`);
-      pipCmd.push('--cache-dir', dockerDownloadCacheDir);
+      cmdOptions.push(
+        '-v',
+        quote_single(`${windowsized}:${dockerDownloadCacheDir}:z`)
+      );
+      pipCmd.push('--cache-dir', quote_single(dockerDownloadCacheDir));
     }
 
     if (process.platform === 'linux') {
@@ -189,7 +201,7 @@ function installRequirements(targetFolder, serverless, options) {
         commands.push(quote(['chown', '-R', '0:0', dockerDownloadCacheDir]));
       }
       // Install requirements with pip
-      commands.push(quote(pipCmd));
+      commands.push(pipCmd.join(' '));
       // Set the ownership of the current folder to user
       commands.push(
         quote([
@@ -213,7 +225,7 @@ function installRequirements(targetFolder, serverless, options) {
       pipCmd = ['/bin/bash', '-c', '"' + commands.join(' && ') + '"'];
     } else {
       // Use same user so --cache-dir works
-      cmdOptions.push('-u', getDockerUid(bindPath));
+      cmdOptions.push('-u', quote_single(getDockerUid(bindPath)));
     }
     cmdOptions.push(dockerImage);
     cmdOptions.push(...pipCmd);
@@ -262,7 +274,7 @@ function dockerPathForWin(options, path) {
   if (process.platform === 'win32' && options.dockerizePip) {
     return path.replace(/\\/g, '/');
   }
-  return path;
+  return quote_single(path);
 }
 
 /** create a filtered requirements.txt without anything from noDeploy


### PR DESCRIPTION
Fixes #242 

# Problem
Could not use this plugin with any path that contains a space character due to missing/insufficient shell escaping/quoting.

# Solution
I'm sorry I couldn't find a simple "quote-all" solution similar to what was in place pre-merge.  These solutions fall apart because certain things you can't quote or docker freaks out, for example features like the 'slim' would fall apart... eg: (see the last line)
```
   [ '-m',
     'pip',
     'install',
     '-t',
     '\'/root/test me/serverless-python-requirements-farley/tests/base/.serverless/requirements\'',
     '-r',
     '\'/root/test me/serverless-python-requirements-farley/tests/base/.serverless/requirements/requirements.txt\'',
     '" && find /root/test me/serverless-python-requirements-farley/tests/base/.serverless/requirements -name \\"*.so\\" -exec strip {} \';\'"' ]
```

The "simple" single test you added for testing in a subfolder only tests one of many use-cases that use various inputs for volumes, caching, etc.  This MR I tested (as you see above) running ALL tests from a folder with a space in it, confirmed working.  Just, not as clean as I would like, but I spent 4 hours trying to make it work with a quote all args type mechanism.  If you don't like this MR's style, please let me know, but I'm out of effort/time/etc.  I can post my diff for my attempts as using a simpler quote-all if interested.  I did not, however, go test if this breaks anything on Windows.  :\  We really need automated testing on Windows somehow @dschep.