### PR TITLE
Don't set pip CWD to target dir

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -227,7 +227,7 @@ function installRequirements(targetFolder, serverless, options) {
     const preparedPath = dockerPathForWin(options, targetFolder);
     cmdOptions.push(getStripCommand(options, preparedPath));
   }
-  let spawnArgs = { cwd: targetFolder, shell: true };
+  let spawnArgs = { shell: true };
   if (process.env.SLS_DEBUG) {
     spawnArgs.stdio = 'inherit';
   }


### PR DESCRIPTION
This fixes #245 by making it so that relative paths in dependencies
resolve correctly

cc @AndrewFarley Just make your own PR with the tests & docker error based on this branch and i'll just merge yours.