### PR TITLE
fix broken windows path

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -147,7 +147,7 @@ function installRequirements(targetFolder, serverless, options) {
     serverless.cli.log(`Docker Image: ${dockerImage}`);
 
     // Prepare bind path depending on os platform
-    const bindPath = dockerPathForWin(getBindPath(serverless, targetFolder));
+    const bindPath = dockerPathForWin(options, getBindPath(serverless, targetFolder));
 
     cmdOptions = ['run', '--rm', '-v', `${bindPath}:/var/task:z`];
     if (options.dockerSsh) {

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -148,7 +148,8 @@ function installRequirements(targetFolder, serverless, options) {
 
     // Prepare bind path depending on os platform
     const bindPath = dockerPathForWin(
-      options, getBindPath(serverless, targetFolder)
+      options,
+      getBindPath(serverless, targetFolder)
     );
 
     cmdOptions = ['run', '--rm', '-v', `${bindPath}:/var/task:z`];

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -147,7 +147,7 @@ function installRequirements(targetFolder, serverless, options) {
     serverless.cli.log(`Docker Image: ${dockerImage}`);
 
     // Prepare bind path depending on os platform
-    const bindPath = getBindPath(serverless, targetFolder);
+    const bindPath = dockerPathForWin(getBindPath(serverless, targetFolder));
 
     cmdOptions = ['run', '--rm', '-v', quote_single(`${bindPath}:/var/task:z`)];
     if (options.dockerSsh) {

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -147,7 +147,9 @@ function installRequirements(targetFolder, serverless, options) {
     serverless.cli.log(`Docker Image: ${dockerImage}`);
 
     // Prepare bind path depending on os platform
-    const bindPath = dockerPathForWin(options, getBindPath(serverless, targetFolder));
+    const bindPath = dockerPathForWin(
+      options, getBindPath(serverless, targetFolder)
+    );
 
     cmdOptions = ['run', '--rm', '-v', `${bindPath}:/var/task:z`];
     if (options.dockerSsh) {

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -149,7 +149,7 @@ function installRequirements(targetFolder, serverless, options) {
     // Prepare bind path depending on os platform
     const bindPath = dockerPathForWin(getBindPath(serverless, targetFolder));
 
-    cmdOptions = ['run', '--rm', '-v', quote_single(`${bindPath}:/var/task:z`)];
+    cmdOptions = ['run', '--rm', '-v', `${bindPath}:/var/task:z`];
     if (options.dockerSsh) {
       // Mount necessary ssh files to work with private repos
       cmdOptions.push(


### PR DESCRIPTION
Current version seems to handle windows paths improperly

``` sh
docker: Error response from daemon: Mount denied:
The source path "C\\:/Users/Paul/Development/solidangle/match-api/app/.serverless/requirements\\:/var/task\\"
is not a valid Windows path.
See 'docker run --help'.
```

Calling `dockerPathForWin` on `bindPath` creation resolves issue.

