### PR TITLE
attempt to fix #184

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -275,7 +275,7 @@ function installRequirements(targetFolder, serverless, options) {
  */
 function dockerPathForWin(options, path) {
   if (process.platform === 'win32' && options.dockerizePip) {
-    return path.replace(/\\/g, '/');
+    return `"${path.replace(/\\/g, '/')}"`;
   }
   return quote_single(path);
 }


### PR DESCRIPTION
Looking at the 1st time #184 was fixed, this should do the trick. Further evidence that #249 is really needed.

@rob-deans, could you try this out?
```
npm i unitedincome/serverless-python-requirements#win-path-spaces
```