### PR TITLE
Fix issue 274

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class ServerlessPythonRequirements {
         usePipenv: true,
         pythonBin:
           process.platform === 'win32'
-            ? 'python.exe'
+            ? 'python'
             : this.serverless.service.provider.runtime || 'python',
         dockerizePip: false,
         dockerSsh: false,

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class ServerlessPythonRequirements {
         usePipenv: true,
         pythonBin:
           process.platform === 'win32'
-            ? 'python'
+            ? 'python.exe'
             : this.serverless.service.provider.runtime || 'python',
         dockerizePip: false,
         dockerSsh: false,
@@ -66,6 +66,9 @@ class ServerlessPythonRequirements {
     );
     if (options.dockerizePip === 'non-linux') {
       options.dockerizePip = process.platform !== 'linux';
+    }
+    if (options.dockerizePip && process.platform === 'win32') {
+      options.pythonBin = 'python';
     }
     if (
       !options.dockerizePip &&

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -10,7 +10,7 @@ const path = require('path');
  */
 function dockerCommand(options) {
   const cmd = 'docker';
-  const ps = spawnSync(cmd, options, { encoding: 'utf-8' });
+  const ps = spawnSync(cmd, options, { encoding: 'utf-8', windowsVerbatimArguments: true });
   if (ps.error) {
     if (ps.error.code === 'ENOENT') {
       throw new Error('docker not found! Please install it.');

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -10,7 +10,10 @@ const path = require('path');
  */
 function dockerCommand(options) {
   const cmd = 'docker';
-  const ps = spawnSync(cmd, options, { encoding: 'utf-8', windowsVerbatimArguments: true });
+  const ps = spawnSync(cmd, options, {
+    encoding: 'utf-8',
+    windowsVerbatimArguments: true
+  });
   if (ps.error) {
     if (ps.error.code === 'ENOENT') {
       throw new Error('docker not found! Please install it.');

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -134,7 +134,7 @@ function getBindPath(serverless, servicePath) {
 
   for (let i = 0; i < bindPaths.length; i++) {
     const bindPath = bindPaths[i];
-    if (tryBindPath(serverless, bindPath, testFile)) {
+    if (tryBindPath(serverless, `"${bindPath}"`, testFile)) {
       return bindPath;
     }
   }


### PR DESCRIPTION
Fix issues on Windows platform using Docker.
- Appended windowsVerbatimArguments option to `spawnSync` on docker.js
- Fix bindPath to enclose by double-quart on docker.js.
- When dockerizePip is enabled and Win32 platform, switch pythonBin from `python.exe` to `python`.