### PR TITLE
Windows Only: When call spawnSyc with shell=true, enclosing by double…

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,9 @@ class ServerlessPythonRequirements {
     if (options.dockerizePip === 'non-linux') {
       options.dockerizePip = process.platform !== 'linux';
     }
+    if (options.dockerizePip && process.platform === 'win32') {
+      options.pythonBin = 'python';
+    }
     if (
       !options.dockerizePip &&
       (options.dockerSsh || options.dockerImage || options.dockerFile)

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -18,6 +18,13 @@ function quote_single(quoteme) {
   return quote([quoteme]);
 }
 
+function quoteFroWin(quoteme) {
+  if (process.platform === 'win32') {
+    return `"${quoteme}"`;
+  }
+  return quoteme;
+}
+
 /**
  * Just generate the requirements file in the .serverless folder
  * @param {string} requirementsPath
@@ -152,7 +159,7 @@ function installRequirements(targetFolder, serverless, options) {
       getBindPath(serverless, targetFolder)
     );
 
-    cmdOptions = ['run', '--rm', '-v', `${bindPath}:/var/task:z`];
+    cmdOptions = ['run', '--rm', '-v', quoteFroWin(`${bindPath}:/var/task:z`)];
     if (options.dockerSsh) {
       // Mount necessary ssh files to work with private repos
       cmdOptions.push(
@@ -275,7 +282,7 @@ function installRequirements(targetFolder, serverless, options) {
  */
 function dockerPathForWin(options, path) {
   if (process.platform === 'win32') {
-    return `"${path.replace(/\\/g, '/')}"`;
+    return `${path.replace(/\\/g, '/')}`;
   } else if (process.platform === 'win32' && !options.dockerizePip) {
     return path;
   }


### PR DESCRIPTION
…-quate -v option.

Remove enclosing by double-quate at dockerPathForWin on Windows platform.
It's caused bad effect on spawnSync without shell=true or windowsVerbatimArguments=true.

closes #274 
closes #281