### PR TITLE
Default `noDeploy` to an empty list

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,14 +217,6 @@ custom:
       - pytest
 ```
 
-To include the default omitted packages, set the `noDeploy` option to an empty
-list:
-```yaml
-custom:
-  pythonRequirements:
-    noDeploy: []
-```
-
 ## Extra Config Options
 ### Caching
 You can enable two kinds of caching with this plugin which are currently both DISABLED by default.  First, a download cache that will cache downloads that pip needs to compile the packages.  And second, a what we call "static caching" which caches output of pip after compiling everything for your requirements file.  Since generally requirements.txt files rarely change, you will often see large amounts of speed improvements when enabling the static cache feature.  These caches will be shared between all your projects if no custom cacheLocation is specified (see below).

--- a/README.md
+++ b/README.md
@@ -207,18 +207,7 @@ custom:
 ```
 ## Omitting Packages
 You can omit a package from deployment with the `noDeploy` option. Note that
-dependencies of omitted packages must explicitly be omitted too. By default,
-the following packages are omitted as they are already installed on Lambda:
-
- * boto3
- * botocore
- * docutils
- * jmespath
- * pip
- * python-dateutil
- * s3transfer
- * setuptools
- * six
+dependencies of omitted packages must explicitly be omitted too.
 
 This example makes it instead omit pytest:
 ```yaml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 version: '{build}'
 init:
+    - cmd: python -m pip install -U pip
     - cmd: pip install pipenv
     - cmd: pip install poetry==1.0.0a2
     - ps: npm i -g serverless

--- a/index.js
+++ b/index.js
@@ -53,17 +53,7 @@ class ServerlessPythonRequirements {
         cacheLocation: false,
         staticCacheMaxVersions: 0,
         pipCmdExtraArgs: [],
-        noDeploy: [
-          'boto3',
-          'botocore',
-          'docutils',
-          'jmespath',
-          'python-dateutil',
-          's3transfer',
-          'six',
-          'pip',
-          'setuptools'
-        ],
+        noDeploy: [],
         vendor: ''
       },
       (this.serverless.service.custom &&

--- a/test.js
+++ b/test.js
@@ -128,7 +128,7 @@ test('default pythonBin can package flask with default options', t => {
   sls(['package']);
   const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
   t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
   t.end();
 });
 
@@ -139,7 +139,7 @@ test('py3.6 can package flask with default options', t => {
   sls([`--pythonBin=${getPythonBin(3)}`, 'package']);
   const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
   t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
   t.end();
 });
 
@@ -248,9 +248,9 @@ test(
 
     const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
     t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.false(
+    t.true(
       zipfiles.includes(`boto3${sep}__init__.py`),
-      'boto3 is NOT packaged'
+      'boto3 is packaged'
     );
     t.end();
   },
@@ -379,7 +379,7 @@ test('py2.7 can package flask with default options', t => {
   sls([`--pythonBin=${getPythonBin(2)}`, 'package']);
   const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
   t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
   t.end();
 });
 
@@ -556,10 +556,7 @@ test(
 
     const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
     t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.false(
-      zipfiles.includes(`boto3${sep}__init__.py`),
-      'boto3 is NOT packaged'
-    );
+    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
     t.end();
   },
   { skip: !canUseDocker() }
@@ -631,7 +628,7 @@ test('pipenv py3.6 can package flask with default options', t => {
   sls(['package']);
   const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
   t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
   t.end();
 });
 
@@ -838,11 +835,11 @@ test('py3.6 can package lambda-decorators using vendor option', t => {
   sls([`--vendor=./vendor`, 'package']);
   const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
   t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
   t.true(
     zipfiles.includes(`lambda_decorators.py`),
     'lambda_decorators.py is packaged'
   );
-  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged');
   t.end();
 });
 
@@ -867,15 +864,12 @@ test(
 
     const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
     t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
     t.true(
       zipfiles.includes(`lambda_decorators.py`),
       'lambda_decorators.py is packaged'
     );
     t.true(zipfiles.includes(`foobar`), 'foobar is packaged');
-    t.false(
-      zipfiles.includes(`boto3${sep}__init__.py`),
-      'boto3 is NOT packaged'
-    );
 
     const zipfiles_with_metadata = listZipFilesWithMetaData(
       '.serverless/sls-py-req-test.zip'
@@ -906,7 +900,7 @@ test('py3.6 can package flask in a project with a space in it', t => {
   sls(['package']);
   const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
   t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
   t.end();
 });
 
@@ -920,10 +914,7 @@ test(
     sls(['--dockerizePip=true', 'package']);
     const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
     t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.false(
-      zipfiles.includes(`boto3${sep}__init__.py`),
-      'boto3 is NOT packaged'
-    );
+    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
     t.end();
   },
   { skip: !canUseDocker() }

--- a/test.js
+++ b/test.js
@@ -716,7 +716,7 @@ test('non build pyproject.toml uses requirements.txt', t => {
   sls(['package']);
   const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
   t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
   t.end();
 });
 
@@ -727,7 +727,7 @@ test('poetry py3.6 can package flask with default options', t => {
   sls(['package']);
   const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
   t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
   t.end();
 });
 

--- a/tests/base/requirements-w-hashes.txt
+++ b/tests/base/requirements-w-hashes.txt
@@ -87,5 +87,3 @@ werkzeug==0.14.1 \
     --hash=sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c \
     --hash=sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b \
     # via flask
-futures==3.2.0 \
-    --hash=sha256:ec0a6cb848cc212002b9828c3e34c675e0c9ff6741dc445cab6fdd4e1085d1f1 \

--- a/tests/base/requirements-w-hashes.txt
+++ b/tests/base/requirements-w-hashes.txt
@@ -87,3 +87,5 @@ werkzeug==0.14.1 \
     --hash=sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c \
     --hash=sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b \
     # via flask
+futures==3.2.0 \
+    --hash=sha256:ec0a6cb848cc212002b9828c3e34c675e0c9ff6741dc445cab6fdd4e1085d1f1 \


### PR DESCRIPTION
Closes #304 

Based on https://github.com/UnitedIncome/serverless-python-requirements/issues/304#issuecomment-454787377 I changed the default for `noDeploy` to an empty array. Not entirely sure if it might have been enough to remove `boto3` and `botocore` instead.