### PR TITLE
fix sls invoke local not works.

### DIFF
--- a/unzip_requirements.py
+++ b/unzip_requirements.py
@@ -13,8 +13,9 @@ if not os.path.exists(pkgdir):
     if os.path.exists(tempdir):
         shutil.rmtree(tempdir)
 
-    zip_requirements = os.path.join(
-        os.environ.get('LAMBDA_TASK_ROOT', os.getcwd()), '.requirements.zip')
+    default_lambda_task_root = os.environ.get('LAMBDA_TASK_ROOT', os.getcwd())
+    lambda_task_root = os.getcwd() if os.environ.get('IS_LOCAL') == 'true' else default_lambda_task_root
+    zip_requirements = os.path.join(lambda_task_root, '.requirements.zip')
 
     zipfile.ZipFile(zip_requirements, 'r').extractall(tempdir)
     os.rename(tempdir, pkgdir)  # Atomic


### PR DESCRIPTION
This plugin not works sls invoke local.


```
Traceback (most recent call last):
  File "/usr/local/lib/node_modules/serverless/lib/plugins/aws/invokeLocal/invoke.py", line 72, in <module>
    module = import_module(args.handler_path.replace('/', '.'))
  File "/Users/hiroshi.toyama/.pyenv/versions/3.6.6/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "./ec2.py", line 1, in <module>
    import unzip_requirements
  File "./unzip_requirements.py", line 20, in <module>
    zipfile.ZipFile(zip_requirements, 'r').extractall(tempdir)
  File "/Users/hiroshi.toyama/.pyenv/versions/3.6.6/lib/python3.6/zipfile.py", line 1090, in __init__
    self.fp = io.open(file, filemode)
FileNotFoundError: [Errno 2] No such file or directory: '/var/task/.requirements.zip'
```

Because LAMBDA_TASK_ROOT set serverless main code, os.getcwd() not work.
https://github.com/serverless/serverless/blob/master/lib/plugins/aws/invokeLocal/index.js#L102
