### PR TITLE
Support editable packages with Pipfile.

### DIFF
--- a/lib/pipenv.js
+++ b/lib/pipenv.js
@@ -1,6 +1,7 @@
 const fse = require('fs-extra');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const { EOL } = require('os');
 
 /**
  * pipenv install
@@ -36,8 +37,24 @@ function pipfileToRequirements() {
   fse.ensureDirSync(path.join(this.servicePath, '.serverless'));
   fse.writeFileSync(
     path.join(this.servicePath, '.serverless/requirements.txt'),
-    res.stdout
+    removeEditableFlagFromRequirementsString(res.stdout)
   );
+}
+
+/**
+ *
+ * @param requirementBuffer
+ * @returns Buffer with editable flags remove
+ */
+function removeEditableFlagFromRequirementsString(requirementBuffer) {
+  const flagStr = '-e ';
+  const lines = requirementBuffer.toString('utf8').split(EOL);
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith(flagStr)) {
+      lines[i] = lines[i].substring(flagStr.length);
+    }
+  }
+  return Buffer.from(lines.join(EOL));
 }
 
 module.exports = { pipfileToRequirements };


### PR DESCRIPTION
Remove editableFlag from .serverless/requirements.txt when using Pipfile.

Based on [#314 (comment)](https://github.com/UnitedIncome/serverless-python-requirements/issues/314)

closes #314