### PR TITLE
Option to turn off binary file stripping when when using `slim: true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ custom:
 This will remove all folders within the installed requirements that match
 the names in `slimPatterns`
 
+#### Option not to strip binaries
+
+In some cases, stripping binaries leads to problems like "ELF load command address/offset not properly aligned", even when done in the Docker environment. You can still slim down the package without `*.so` files with
+```yaml
+custom:
+  pythonRequirements:
+    slim: true
+    strip: false
+```
+
 ### Lamba Layer
 Another method for dealing with large dependencies is to put them into a
 [Lambda Layer](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).

--- a/lib/slim.js
+++ b/lib/slim.js
@@ -3,7 +3,12 @@ const glob = require('glob-all');
 const fse = require('fs-extra');
 
 const getStripMode = options => {
-  if (options.slim === false || options.slim === 'false') {
+  if (
+    options.strip === false ||
+    options.strip === 'false' ||
+    options.slim === false ||
+    options.slim === 'false'
+  ) {
     return 'skip';
   } else if (options.dockerizePip) {
     return 'docker';


### PR DESCRIPTION
As #318 and [#216 - comment](
https://github.com/UnitedIncome/serverless-python-requirements/issues/216#issuecomment-419037475) note, stripping `*.so` files can mess things up on Lambda, even when done in Docker.

For example, this is the error you will get if you strip opencv: `ImportError: /tmp/sls-py-req/cv2/cv2.cpython-36m-x86_64-linux-gnu.so: ELF load command address/offset not properly aligned`

In these cases, it is useful to simply turn off stripping while retaining the other behaviors of `slim: true`.