### PR TITLE
use sha256 instead of md5

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -9,7 +9,7 @@ const { buildImage, getBindPath, getDockerUid } = require('./docker');
 const { getStripCommand, getStripMode, deleteFiles } = require('./slim');
 const {
   checkForAndDeleteMaxCacheVersions,
-  md5Path,
+  sha256Path,
   getRequirementsWorkingPath,
   getUserCachePath
 } = require('./shared');
@@ -474,7 +474,7 @@ function installRequirementsIfNeeded(
   }
 
   // Then generate our MD5 Sum of this requirements file to determine where it should "go" to and/or pull cache from
-  const reqChecksum = md5Path(slsReqsTxt);
+  const reqChecksum = sha256Path(slsReqsTxt);
 
   // Then figure out where this cache should be, if we're caching, if we're in a module, etc
   const workingReqsFolder = getRequirementsWorkingPath(

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -1,9 +1,11 @@
 const Appdir = require('appdirectory');
 const rimraf = require('rimraf');
-const md5File = require('md5-file');
+//const md5File = require('md5-file');
 const glob = require('glob-all');
 const path = require('path');
 const fse = require('fs-extra');
+const sha256File = require('sha256-file');
+
 
 /**
  * This helper will check if we're using static cache and have max
@@ -101,7 +103,7 @@ function getUserCachePath(options) {
  * @return {string}
  */
 function md5Path(fullpath) {
-  return md5File.sync(fullpath);
+  return sha256File(fullpath);
 }
 
 module.exports = {

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -108,5 +108,5 @@ module.exports = {
   checkForAndDeleteMaxCacheVersions,
   getRequirementsWorkingPath,
   getUserCachePath,
-  md5Path
+  sha256Path
 };

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -5,7 +5,6 @@ const path = require('path');
 const fse = require('fs-extra');
 const sha256File = require('sha256-file');
 
-
 /**
  * This helper will check if we're using static cache and have max
  * versions enabled and will delete older versions in a fifo fashion

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -1,6 +1,5 @@
 const Appdir = require('appdirectory');
 const rimraf = require('rimraf');
-//const md5File = require('md5-file');
 const glob = require('glob-all');
 const path = require('path');
 const fse = require('fs-extra');
@@ -102,7 +101,7 @@ function getUserCachePath(options) {
  * @param  {string} fullpath
  * @return {string}
  */
-function md5Path(fullpath) {
+function sha256Path(fullpath) {
   return sha256File(fullpath);
 }
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "lodash.set": "^4.3.2",
     "lodash.uniqby": "^4.0.0",
     "lodash.values": "^4.3.0",
-    "md5-file": "^4.0.0",
     "rimraf": "^2.6.2",
     "shell-quote": "^1.6.1",
     "sha256-file": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lodash.values": "^4.3.0",
     "md5-file": "^4.0.0",
     "rimraf": "^2.6.2",
-    "shell-quote": "^1.6.1"
+    "shell-quote": "^1.6.1",
     "sha256-file": "1.0.0"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "md5-file": "^4.0.0",
     "rimraf": "^2.6.2",
     "shell-quote": "^1.6.1"
+    "sha256-file": "1.0.0"
   },
   "eslintConfig": {
     "extends": "eslint:recommended",

--- a/test.js
+++ b/test.js
@@ -1704,7 +1704,7 @@ test(
       'package'
     ]);
     const cachepath = getUserCachePath();
-    const cacheFolderHash = md5Path('.serverless/requirements.txt');
+    const cacheFolderHash = sha256Path('.serverless/requirements.txt');
     t.true(
       pathExistsSync(`${cachepath}${sep}downloadCacheslspyc${sep}http`),
       'http exists in download-cache'
@@ -1724,7 +1724,7 @@ test('py3.6 uses static cache', t => {
   npm(['i', path]);
   sls(['--useStaticCache=true', 'package']);
   const cachepath = getUserCachePath();
-  const cacheFolderHash = md5Path('.serverless/requirements.txt');
+  const cacheFolderHash = sha256Path('.serverless/requirements.txt');
   t.true(
     pathExistsSync(`${cachepath}${sep}${cacheFolderHash}_slspyc${sep}flask`),
     'flask exists in static-cache'
@@ -1758,7 +1758,7 @@ test('py3.6 uses static cache with cacheLocation option', t => {
   npm(['i', path]);
   const cachepath = '.requirements-cache';
   sls(['--useStaticCache=true', `--cacheLocation=${cachepath}`, 'package']);
-  const cacheFolderHash = md5Path('.serverless/requirements.txt');
+  const cacheFolderHash = sha256Path('.serverless/requirements.txt');
   t.true(
     pathExistsSync(`${cachepath}${sep}${cacheFolderHash}_slspyc${sep}flask`),
     'flask exists in static-cache'
@@ -1785,7 +1785,7 @@ test(
       'package'
     ]);
     const cachepath = getUserCachePath();
-    const cacheFolderHash = md5Path('.serverless/requirements.txt');
+    const cacheFolderHash = sha256Path('.serverless/requirements.txt');
     t.true(
       pathExistsSync(`${cachepath}${sep}${cacheFolderHash}_slspyc${sep}flask`),
       'flask exists in static-cache'

--- a/test.js
+++ b/test.js
@@ -14,7 +14,7 @@ const {
 const { quote } = require('shell-quote');
 const { sep } = require('path');
 
-const { getUserCachePath, md5Path } = require('./lib/shared');
+const { getUserCachePath, sha256Path } = require('./lib/shared');
 
 const initialWorkingDir = process.cwd();
 
@@ -1679,7 +1679,7 @@ test('py3.6 uses static and download cache', t => {
   npm(['i', path]);
   sls(['--useDownloadCache=true', '--useStaticCache=true', 'package']);
   const cachepath = getUserCachePath();
-  const cacheFolderHash = md5Path('.serverless/requirements.txt');
+  const cacheFolderHash = sha256Path('.serverless/requirements.txt');
   t.true(
     pathExistsSync(`${cachepath}${sep}downloadCacheslspyc${sep}http`),
     'http exists in download-cache'


### PR DESCRIPTION
Currently, `serverless-python-requirements`  does not work in our environment because this library is using md5. This algorithm is not FIPS compliant. We are getting the following error: 

`digital envelope routines:EVP_DigestInit_ex:disabled for fips`

I created this PR so that we can move away from using md5 and use sha256 algorithm which is FIPS compliant. 