### PR TITLE
Use spawnArgs when launching spawnSync

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -288,7 +288,7 @@ function installRequirements(targetFolder, serverless, options) {
   serverless.cli.log(`Running ${quote(dockerCmd)}...`);
 
   filterCommands(mainCmds).forEach(([cmd, ...args]) => {
-    const res = spawnSync(cmd, args);
+    const res = spawnSync(cmd, args, spawnArgs);
     if (res.error) {
       if (res.error.code === 'ENOENT') {
         const advice =


### PR DESCRIPTION
Looks like `spawnArgs` was defined but never used - this caused a bug when trying to use the option:

```
pipCmdExtraArgs:
      - --install-option="--install-scripts=/var/task"
```