### PR TITLE
Allow arbitrary extra args to be passed to docker build and dockerized pip install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,18 @@ custom:
           - --compile
 ```
 
+### Extra Docker arguments
+
+You can specify extra arguments to be passed to [docker build](https://docs.docker.com/engine/reference/commandline/build/) during the build step, and [docker run](https://docs.docker.com/engine/reference/run/) during the dockerized pip install step:
+
+```yaml
+custom:
+  pythonRequirements:
+    dockerizePip: true
+    dockerBuildCmdExtraArgs: ["--build-arg", "MY_GREAT_ARG=123"]
+    dockerRunCmdExtraArgs: ["-v", "${env:PWD}:/my-app"]
+```
+
 
 ### Customize requirements file name
 [Some `pip` workflows involve using requirements files not named

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ class ServerlessPythonRequirements {
         dockerImage: null,
         dockerFile: null,
         dockerEnv: false,
+        dockerRunCmdExtraArgs: [],
         useStaticCache: false,
         useDownloadCache: false,
         cacheLocation: false,

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ class ServerlessPythonRequirements {
         dockerImage: null,
         dockerFile: null,
         dockerEnv: false,
+        dockerBuildCmdExtraArgs: [],
         dockerRunCmdExtraArgs: [],
         useStaticCache: false,
         useDownloadCache: false,

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -25,11 +25,21 @@ function dockerCommand(options) {
 /**
  * Build the custom Docker image
  * @param {string} dockerFile
+ * @param {string[]} extraArgs
  * @return {string} The name of the built docker image.
  */
-function buildImage(dockerFile) {
+function buildImage(dockerFile, extraArgs) {
   const imageName = 'sls-py-reqs-custom';
-  const options = ['build', '-f', dockerFile, '-t', imageName, '.'];
+  const options = ['build', '-f', dockerFile, '-t', imageName];
+
+  if (Array.isArray(extraArgs)) {
+    options.push(...extraArgs);
+  } else {
+    throw new Error('dockerRunCmdExtraArgs option must be an array');
+  }
+
+  options.push('.');
+
   dockerCommand(options);
   return imageName;
 }

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -259,6 +259,13 @@ function installRequirements(targetFolder, serverless, options) {
       // Use same user so --cache-dir works
       dockerCmd.push('-u', getDockerUid(bindPath));
     }
+
+    if (Array.isArray(options.dockerRunCmdExtraArgs)) {
+      dockerCmd.push(...options.dockerRunCmdExtraArgs);
+    } else {
+      throw new Error('dockerRunCmdExtraArgs option must be an array');
+    }
+
     dockerCmd.push(dockerImage);
   }
 

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -180,7 +180,7 @@ function installRequirements(targetFolder, serverless, options) {
       serverless.cli.log(
         `Building custom docker image from ${options.dockerFile}...`
       );
-      dockerImage = buildImage(options.dockerFile);
+      dockerImage = buildImage(options.dockerFile, options.dockerBuildCmdExtraArgs);
     } else {
       dockerImage = options.dockerImage;
     }

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -180,7 +180,10 @@ function installRequirements(targetFolder, serverless, options) {
       serverless.cli.log(
         `Building custom docker image from ${options.dockerFile}...`
       );
-      dockerImage = buildImage(options.dockerFile, options.dockerBuildCmdExtraArgs);
+      dockerImage = buildImage(
+        options.dockerFile,
+        options.dockerBuildCmdExtraArgs
+      );
     } else {
       dockerImage = options.dockerImage;
     }


### PR DESCRIPTION
These changes allow arbitrary arguments to be passed to the `docker build` step and `docker run` step in the dockerized pip install case through through the creation of 2 new options: `dockerBuildCmdExtraArgs` and `dockerRunCmdExtraArgs`, respectively.

Both new options accept arrays of strings to be pushed onto the docker command argument arrays.

This is necessary to be able to pass Docker build arguments to the image build step, as well as to be able to attach volumes which may be referenced by the use of a `file://`-style entry in `requirements.txt`.