### PR TITLE
Fix poetry with git dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,21 @@ custom:
     usePoetry: false
 ```
 
+### Poetry with git dependencies
+Poetry by default generates the exported requirements.txt file with `-e` and that breaks pip with `-t` parameter
+(used to install all requirements in a specific folder). In order to fix that we remove all `-e ` from the generated file but,
+for that to work you need to add the git dependencies in a specific way.
+
+Instead of:
+```toml
+[tool.poetry.dependencies]
+bottle = {git = "git@github.com/bottlepy/bottle.git", tag = "0.12.16"}
+```
+it has to be:
+```toml
+[tool.poetry.dependencies]
+bottle = {git = "ssh://git@github.com/bottlepy/bottle.git", tag = "0.12.16"}
+```
 
 ## Dealing with Lambda's size limitations
 To help deal with potentially large dependencies (for example: `numpy`, `scipy`

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -317,7 +317,7 @@ function installRequirements(targetFolder, serverless, options) {
       throw res.error;
     }
     if (res.status !== 0) {
-      throw new Error(res.stderr);
+      throw new Error(`STDOUT: ${res.stdout}\n\nSTDERR: ${res.stderr}`);
     }
   });
   // If enabled slimming, delete files in slimPatterns

--- a/lib/poetry.js
+++ b/lib/poetry.js
@@ -32,9 +32,19 @@ function pyprojectTomlToRequirements() {
   if (res.status !== 0) {
     throw new Error(res.stderr);
   }
+
+  const editableLine = new RegExp(/^-e /gm);
+  const sourceRequirements = path.join(this.servicePath, 'requirements.txt');
+  const requirementsContents = fse.readFileSync(sourceRequirements, { encoding: 'utf-8' });
+  
+  if (requirementsContents.match(editableLine)) {
+    this.serverless.cli.log('The generated file contains -e lines, removing them...');
+    fse.writeFileSync(sourceRequirements, requirementsContents.replace(editableLine, ''))
+  }
+
   fse.ensureDirSync(path.join(this.servicePath, '.serverless'));
   fse.moveSync(
-    path.join(this.servicePath, 'requirements.txt'),
+    sourceRequirements,
     path.join(this.servicePath, '.serverless', 'requirements.txt')
   );
 }

--- a/lib/poetry.js
+++ b/lib/poetry.js
@@ -33,19 +33,19 @@ function pyprojectTomlToRequirements() {
     throw new Error(res.stderr);
   }
 
-  const editableLine = new RegExp(/^-e /gm);
+  const editableFlag = new RegExp(/^-e /gm);
   const sourceRequirements = path.join(this.servicePath, 'requirements.txt');
   const requirementsContents = fse.readFileSync(sourceRequirements, {
     encoding: 'utf-8'
   });
 
-  if (requirementsContents.match(editableLine)) {
+  if (requirementsContents.match(editableFlag)) {
     this.serverless.cli.log(
       'The generated file contains -e lines, removing them...'
     );
     fse.writeFileSync(
       sourceRequirements,
-      requirementsContents.replace(editableLine, '')
+      requirementsContents.replace(editableFlag, '')
     );
   }
 

--- a/lib/poetry.js
+++ b/lib/poetry.js
@@ -35,11 +35,18 @@ function pyprojectTomlToRequirements() {
 
   const editableLine = new RegExp(/^-e /gm);
   const sourceRequirements = path.join(this.servicePath, 'requirements.txt');
-  const requirementsContents = fse.readFileSync(sourceRequirements, { encoding: 'utf-8' });
-  
+  const requirementsContents = fse.readFileSync(sourceRequirements, {
+    encoding: 'utf-8'
+  });
+
   if (requirementsContents.match(editableLine)) {
-    this.serverless.cli.log('The generated file contains -e lines, removing them...');
-    fse.writeFileSync(sourceRequirements, requirementsContents.replace(editableLine, ''))
+    this.serverless.cli.log(
+      'The generated file contains -e lines, removing them...'
+    );
+    fse.writeFileSync(
+      sourceRequirements,
+      requirementsContents.replace(editableLine, '')
+    );
   }
 
   fse.ensureDirSync(path.join(this.servicePath, '.serverless'));

--- a/test.js
+++ b/test.js
@@ -727,8 +727,13 @@ test('poetry py3.6 can package flask with default options', t => {
   sls(['package']);
   const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
   t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+<<<<<<< HEAD
   t.true(zipfiles.includes(`bottle${sep}__init__.py`), 'bottle is packaged');
   t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+=======
+  t.true(zipfiles.includes(`bottle.py`), 'bottle is packaged');
+  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged');
+>>>>>>> Fix wrongly expected file in test
   t.end();
 });
 

--- a/test.js
+++ b/test.js
@@ -727,6 +727,7 @@ test('poetry py3.6 can package flask with default options', t => {
   sls(['package']);
   const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
   t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`bottle${sep}__init__.py`), 'bottle is packaged');
   t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
   t.end();
 });

--- a/test.js
+++ b/test.js
@@ -727,7 +727,7 @@ test('poetry py3.6 can package flask with default options', t => {
   sls(['package']);
   const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
   t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-  t.true(zipfiles.includes(`bottle${sep}__init__.py`), 'bottle is packaged');
+  t.true(zipfiles.includes(`bottle.py`), 'bottle is packaged');
   t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
   t.end();
 });

--- a/test.js
+++ b/test.js
@@ -727,13 +727,8 @@ test('poetry py3.6 can package flask with default options', t => {
   sls(['package']);
   const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
   t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-<<<<<<< HEAD
   t.true(zipfiles.includes(`bottle${sep}__init__.py`), 'bottle is packaged');
   t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-=======
-  t.true(zipfiles.includes(`bottle.py`), 'bottle is packaged');
-  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged');
->>>>>>> Fix wrongly expected file in test
   t.end();
 });
 

--- a/tests/poetry/poetry.lock
+++ b/tests/poetry/poetry.lock
@@ -4,12 +4,12 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = "*"
-version = "1.9.80"
+version = "1.9.150"
 
 [package.dependencies]
-botocore = ">=1.12.80,<1.13.0"
+botocore = ">=1.12.150,<1.13.0"
 jmespath = ">=0.7.1,<1.0.0"
-s3transfer = ">=0.1.10,<0.2.0"
+s3transfer = ">=0.2.0,<0.3.0"
 
 [[package]]
 category = "main"
@@ -17,7 +17,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = "*"
-version = "1.12.80"
+version = "1.12.150"
 
 [package.dependencies]
 docutils = ">=0.10"
@@ -39,6 +39,10 @@ optional = false
 python-versions = "*"
 version = "0.12.16"
 
+[package.source]
+reference = "0.12.16"
+type = "git"
+url = "ssh://git@github.com/bottlepy/bottle.git"
 [[package]]
 category = "main"
 description = "Composable command line interface toolkit"
@@ -88,7 +92,7 @@ description = "A small but fast and easy to use stand-alone template engine writ
 name = "jinja2"
 optional = false
 python-versions = "*"
-version = "2.10"
+version = "2.10.1"
 
 [package.dependencies]
 MarkupSafe = ">=0.23"
@@ -102,7 +106,7 @@ description = "JSON Matching Expressions"
 name = "jmespath"
 optional = false
 python-versions = "*"
-version = "0.9.3"
+version = "0.9.4"
 
 [[package]]
 category = "main"
@@ -110,7 +114,7 @@ description = "Safely add untrusted strings to HTML/XML markup."
 name = "markupsafe"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 category = "main"
@@ -119,7 +123,7 @@ marker = "python_version >= \"2.7\""
 name = "python-dateutil"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.7.5"
+version = "2.8.0"
 
 [package.dependencies]
 six = ">=1.5"
@@ -130,10 +134,10 @@ description = "An Amazon S3 Transfer Manager"
 name = "s3transfer"
 optional = false
 python-versions = "*"
-version = "0.1.13"
+version = "0.2.0"
 
 [package.dependencies]
-botocore = ">=1.3.0,<2.0.0"
+botocore = ">=1.12.36,<2.0.0"
 
 [[package]]
 category = "main"
@@ -151,7 +155,7 @@ marker = "python_version >= \"3.4\""
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
-version = "1.24.1"
+version = "1.24.3"
 
 [package.extras]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
@@ -162,31 +166,31 @@ category = "main"
 description = "The comprehensive WSGI web application library."
 name = "werkzeug"
 optional = false
-python-versions = "*"
-version = "0.14.1"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.15.4"
 
 [package.extras]
-dev = ["coverage", "pytest", "sphinx", "tox"]
+dev = ["pytest", "coverage", "tox", "sphinx", "pallets-sphinx-themes", "sphinx-issues"]
 termcolor = ["termcolor"]
 watchdog = ["watchdog"]
 
 [metadata]
-content-hash = "fa5a641a2c19871b5899fbc700d6375250a5d2e327832a012296af6a31c8093a"
+content-hash = "3b275a1ce61e115344002b4303657cbb2e2c65833b1682486ed890529a434654"
 python-versions = "^3.6"
 
 [metadata.hashes]
-boto3 = ["122603b00f8c458236d1bd09850bdea56fc45f271e75ca38e66dbce37f72cada", "99ec19dc4f0aa8a8354db7baebe1ff57bd18aeb6a539b28693b2e8ca8dc3d85b"]
-botocore = ["76a2969278250e010253ddf514f4b54eaa7d2b1430f682874c3c2ab92f25a96d", "8c579bac9abeaff1270a7a25964b01d3db1367f42fa5f826e1303ec8a4b13cef"]
-bottle = ["9c310da61e7df2b6ac257d8a90811899ccb3a9743e77e947101072a2e3186726", "ca43beafbdccabbe31b758a4f34d1e44985a9b9539516775208b2b0f903eafa0"]
+boto3 = ["1253809000b3b9020c6dde3e8b0b75e6c02547e2760656d8bccc40fd2a7284a6", "e32a1a324ddfb652dedd550fd288ad85cc8d448ed19315f39fbe7b6171a30dc8"]
+botocore = ["946fd5e85378c3c597d6b9f495706576a0fc0000b216e30346ed7ee796ff50c8", "f82e44af499a8f806c363ab4e26df82195b5b190c4169ccfbfbc98e55aa22bf7"]
+bottle = []
 click = ["2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13", "5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"]
 docutils = ["02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6", "51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274", "7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"]
 flask = ["2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48", "a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"]
 itsdangerous = ["321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19", "b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"]
-jinja2 = ["74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd", "f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"]
-jmespath = ["6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64", "f11b4461f425740a1d908e9a3f7365c3d2e569f6ca68a2ff8bc5bcd9676edd63"]
-markupsafe = ["048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432", "130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b", "19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9", "1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af", "1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834", "1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd", "1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d", "31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7", "3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b", "4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3", "525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c", "52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2", "52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7", "5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36", "5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1", "5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e", "7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1", "83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c", "857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856", "98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550", "bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492", "d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672", "e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401", "edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6", "efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6", "f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c", "f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd", "fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"]
-python-dateutil = ["063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93", "88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"]
-s3transfer = ["90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1", "c7a9ec356982d5e9ab2d4b46391a7d6a950e2b04c472419f5fdec70cc0ada72f"]
+jinja2 = ["065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013", "14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"]
+jmespath = ["3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6", "bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"]
+markupsafe = ["00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473", "09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161", "09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235", "1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5", "24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff", "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b", "43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1", "46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e", "500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183", "535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66", "62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1", "6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1", "717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e", "79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b", "7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905", "88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735", "8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d", "98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e", "9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d", "9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c", "ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21", "b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2", "b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5", "b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b", "ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6", "c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f", "cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f", "e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"]
+python-dateutil = ["7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb", "c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"]
+s3transfer = ["7b9ad3213bff7d357f888e0fab5101b56fa1a0548ee77d121c3a3dbfbef4cb2e", "f23d5cb7d862b104401d9021fc82e5fa0e0cf57b7660a1331425aab0c691d021"]
 six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]
-urllib3 = ["61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39", "de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"]
-werkzeug = ["c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c", "d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"]
+urllib3 = ["2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4", "a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"]
+werkzeug = ["865856ebb55c4dcd0630cdd8f3331a1847a819dda7e8c750d3db6f2aa6c0209c", "a0b915f0815982fb2a09161cb8f31708052d0951c3ba433ccc5e1aa276507ca6"]

--- a/tests/poetry/pyproject.toml
+++ b/tests/poetry/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Your Name <you@example.com>"]
 [tool.poetry.dependencies]
 python = "^3.6"
 Flask = "^1.0"
-bottle = "^0.12.16"
+bottle = {git = "ssh://git@github.com/bottlepy/bottle.git", tag = "0.12.16"}
 boto3 = "^1.9"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Hey there, this PR is to fix problems when you use poetry and git dependencies.
By default, poetry will generate a `requirements.txt` with `-e`/`--editable` flag which does not work well with `-t` (`--target`). This PR will read that file and rewrite the lines to make sure pip won't try to install in a wrong way.