### PR TITLE
Add support to copy extra files from the Docker image to the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,26 +402,25 @@ custom:
 
 ## Native Code Dependencies During Runtime
 
-Some Python packages require extra OS libraries (`*.so` files) at runtime. You need to manually include these files in the root directory of your Serverless package. The simplest way to do this is to commit the files to your repository:
+Some Python packages require extra OS libraries (`*.so` files) at runtime. You need to manually include these files in the root directory of your Serverless package. The simplest way to do this is to use the `dockerExtraFiles` option.
 
-For instance, the `mysqlclient` package requires `libmysqlclient.so.1020`. If you use the Dockerfile from the previous section, you can extract this file from the builder Dockerfile:
+For instance, the `mysqlclient` package requires `libmysqlclient.so.1020`. If you use the Dockerfile from the previous section, add an item to the `dockerExtraFiles` option in your `serverless.yml`:
 
-1. Extract the library:
-```bash
-docker run --rm -v "$(pwd):/var/task" sls-py-reqs-custom cp -v /usr/lib64/mysql57/libmysqlclient.so.1020 .
+```yaml
+custom:
+  pythonRequirements:
+    dockerExtraFiles:
+      - /usr/lib64/mysql57/libmysqlclient.so.1020
 ```
-(If you get the error `Unable to find image 'sls-py-reqs-custom:latest' locally`, run `sls package` to build the image.)
-2. Commit to your repo:
-```bash
-git add libmysqlclient.so.1020
-git commit -m "Add libmysqlclient.so.1020"
-```
-3. Verify the library gets included in your package:
+
+Then verify the library gets included in your package:
+
 ```bash
 sls package
 zipinfo .serverless/xxx.zip
 ```
-(If you can't see the library, you might need to adjust your package include/exclude configuration in `serverless.yml`.)
+
+If you can't see the library, you might need to adjust your package include/exclude configuration in `serverless.yml`.
 
 ## Optimising packaging time
 

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ class ServerlessPythonRequirements {
         dockerEnv: false,
         dockerBuildCmdExtraArgs: [],
         dockerRunCmdExtraArgs: [],
+        dockerExtraFiles: [],
         useStaticCache: false,
         useDownloadCache: false,
         cacheLocation: false,

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -249,6 +249,16 @@ function installRequirements(targetFolder, serverless, options) {
         `${process.getuid()}:${process.getgid()}`,
         '/var/task'
       ]);
+    } else {
+      // Use same user so --cache-dir works
+      dockerCmd.push('-u', getDockerUid(bindPath));
+    }
+
+    for (let path of options.dockerExtraFiles) {
+      pipCmds.push(['cp', path, '/var/task/']);
+    }
+
+    if (process.platform === 'linux') {
       if (options.useDownloadCache) {
         // Set the ownership of the download cache dir back to user
         pipCmds.push([
@@ -258,9 +268,6 @@ function installRequirements(targetFolder, serverless, options) {
           dockerDownloadCacheDir
         ]);
       }
-    } else {
-      // Use same user so --cache-dir works
-      dockerCmd.push('-u', getDockerUid(bindPath));
     }
 
     if (Array.isArray(options.dockerRunCmdExtraArgs)) {


### PR DESCRIPTION
This allows native OS libraries (`*.so` files) to be copied to the
serverless archive to be available at runtime. This introduces the new
option `dockerExtraFiles`, a list of paths on the Docker image to copy.

For example, the `mysqlclient` package requires
`libmysqlclient.so.1020`. One can now add an item to the
`dockerExtraFiles` option in their `serverless.yml`:

    pythonRequirements:
      dockerExtraFiles:
        - /usr/lib64/mysql57/libmysqlclient.so.1020

This file will be available at runtime in the Lambda function.

This removes the need to manage these files in a more manual way and
avoids the need to commit binary files one's repository.