### PR TITLE
Set prettier parser to "babel" to fix lint warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
   "prettier": {
     "semi": true,
     "singleQuote": true,
-    "parser": "babylon"
+    "parser": "babel"
   }
 }


### PR DESCRIPTION
Fixes warning of the form:

    [warn] { parser: "babylon" } is deprecated; we now treat it as { parser: "babel" }.