### PR TITLE
Prevent serverless package hash from changing

### DIFF
--- a/lib/inject.js
+++ b/lib/inject.js
@@ -39,9 +39,10 @@ function injectRequirements(requirementsPath, packagePath, options) {
         .map(([file, relativeFile]) =>
           Promise.all([file, relativeFile, fse.statAsync(file)])
         )
-        .map(([file, relativeFile, fileStat]) =>
+        .mapSeries(([file, relativeFile, fileStat]) =>
           zipFile(zip, relativeFile, fse.readFileAsync(file), {
-            unixPermissions: fileStat.mode
+            unixPermissions: fileStat.mode,
+            createFolders: false
           })
         )
         .then(() => writeZip(zip, packagePath))

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ const crossSpawn = require('cross-spawn');
 const deasync = require('deasync-promise');
 const glob = require('glob-all');
 const JSZip = require('jszip');
+const sha256File = require('sha256-file');
 const tape = require('tape');
 const {
   chmodSync,
@@ -129,6 +130,17 @@ test('default pythonBin can package flask with default options', t => {
   const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
   t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
   t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
+
+test('py3.6 packages have the same hash', t => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package']);
+  const fileHash = sha256File('.serverless/sls-py-req-test.zip');
+  sls(['package']);
+  t.equal(sha256File('.serverless/sls-py-req-test.zip'), fileHash, 'packages have the same hash');
   t.end();
 });
 


### PR DESCRIPTION
Modify the following to prevent modification of the serverless deploy package file hash.

+ Inserting packages asynchronously changes the order
+ The timestamp is changed when creating a folder in the package zip file with `jszip`

Changing the file hash will cause unnecessary deployment.


I'm sorry my English is not good.