### PR TITLE
Fix poetry 1.0.0b1 export prints to stdout by default

### DIFF
--- a/lib/poetry.js
+++ b/lib/poetry.js
@@ -35,9 +35,7 @@ function pyprojectTomlToRequirements() {
 
   const editableFlag = new RegExp(/^-e /gm);
   const sourceRequirements = path.join(this.servicePath, 'requirements.txt');
-  const requirementsContents = fse.readFileSync(sourceRequirements, {
-    encoding: 'utf-8'
-  });
+  const requirementsContents = res.stdout.toString();
 
   if (requirementsContents.match(editableFlag)) {
     this.serverless.cli.log(

--- a/lib/poetry.js
+++ b/lib/poetry.js
@@ -35,7 +35,11 @@ function pyprojectTomlToRequirements() {
 
   const editableFlag = new RegExp(/^-e /gm);
   const sourceRequirements = path.join(this.servicePath, 'requirements.txt');
-  const requirementsContents = res.stdout.toString();
+  const requirementsContents =
+    res.stdout.toString() ||
+    fse.readFileSync(sourceRequirements, {
+      encoding: 'utf-8'
+    });
 
   if (requirementsContents.match(editableFlag)) {
     this.serverless.cli.log(

--- a/lib/poetry.js
+++ b/lib/poetry.js
@@ -36,7 +36,7 @@ function pyprojectTomlToRequirements() {
   const editableFlag = new RegExp(/^-e /gm);
   const sourceRequirements = path.join(this.servicePath, 'requirements.txt');
   const requirementsContents =
-    res.stdout.toString() || // As of poetry 1.0.0b1, requirements.txt is printed to standard output when the -o option is not specified.
+    res.stdout.toString().trim() || // As of poetry 1.0.0b1, requirements.txt is printed to standard output when the -o option is not specified.
     fse.readFileSync(sourceRequirements, {
       encoding: 'utf-8'
     });

--- a/lib/poetry.js
+++ b/lib/poetry.js
@@ -36,7 +36,7 @@ function pyprojectTomlToRequirements() {
   const editableFlag = new RegExp(/^-e /gm);
   const sourceRequirements = path.join(this.servicePath, 'requirements.txt');
   const requirementsContents =
-    res.stdout.toString() ||
+    res.stdout.toString() || // As of poetry 1.0.0b1, requirements.txt is printed to standard output when the -o option is not specified.
     fse.readFileSync(sourceRequirements, {
       encoding: 'utf-8'
     });

--- a/test.js
+++ b/test.js
@@ -51,6 +51,7 @@ const sls = mkCommand('sls');
 const git = mkCommand('git');
 const npm = mkCommand('npm');
 const perl = mkCommand('perl');
+const poetry = mkCommand('poetry');
 
 const setup = () => {
   removeSync(getUserCachePath());
@@ -1874,3 +1875,17 @@ test(
   },
   { skip: !canUseDocker() }
 );
+
+// From this point on, the version of the poetry is 1.0.0a0
+test('poetry1.0.0a0 py3.6 can package flask with default options', t => {
+  process.chdir('tests/poetry');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  poetry(['self', 'update', '--preview', '1.0.0a0']);
+  sls(['package']);
+  const zipfiles = listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`bottle.py`), 'bottle is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});


### PR DESCRIPTION
The `export` command for poetry 1.0.0b1 outputs to standard output if the `-o` option is not specified.

Modified to use `spawnSync` return values.