### PR TITLE
Add docker login message

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -149,7 +149,7 @@ function getBindPath(serverless, servicePath) {
     }
   }
 
-  throw new Error('Unable to find good bind path format');
+  throw new Error('Unable to find good bind path format (try `docker login` manually)');
 }
 
 /**


### PR DESCRIPTION
Running `docker login` manually seemed like a fix, so I added it as a message for the error.
I can try to find out if it is a Windows OS, and only show it then, but I wanted to get some feedback before writing more code.

Will probably help solve:
https://github.com/UnitedIncome/serverless-python-requirements/issues/210
and
https://github.com/UnitedIncome/serverless-python-requirements/issues/300

