### PR TITLE
Fixed saving requirements.txt when using poetry

### DIFF
--- a/lib/poetry.js
+++ b/lib/poetry.js
@@ -49,6 +49,11 @@ function pyprojectTomlToRequirements() {
       sourceRequirements,
       requirementsContents.replace(editableFlag, '')
     );
+  } else {
+    fse.writeFileSync(
+      sourceRequirements,
+      requirementsContents
+    );
   }
 
   fse.ensureDirSync(path.join(this.servicePath, '.serverless'));


### PR DESCRIPTION
Fixes https://github.com/UnitedIncome/serverless-python-requirements/issues/409