### PR TITLE
Change to poetry command to export requirements.txt resolving #445

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ and requires that poetry is installed with the --preview flag.
 TL;DR Install poetry with the `--preview` flag.
 
 If you include a `pyproject.toml` and have `poetry` installed instead of a `requirements.txt` this will use
-`poetry export --without-hashes -f requirements.txt` to generate them. It is fully compatible with all options such as `zip` and
+`poetry export --without-hashes -f requirements.txt -o requirements.txt` to generate them. It is fully compatible with all options such as `zip` and
 `dockerizePip`. If you don't want this plugin to generate it for you, set the following option:
 ```yaml
 custom:

--- a/lib/poetry.js
+++ b/lib/poetry.js
@@ -16,7 +16,7 @@ function pyprojectTomlToRequirements() {
 
   const res = spawnSync(
     'poetry',
-    ['export', '--without-hashes', '-f', 'requirements.txt', '>', 'requirements.txt'],
+    ['export', '--without-hashes', '-f', 'requirements.txt', '-o', 'requirements.txt'],
     {
       cwd: this.servicePath
     }

--- a/lib/poetry.js
+++ b/lib/poetry.js
@@ -16,7 +16,7 @@ function pyprojectTomlToRequirements() {
 
   const res = spawnSync(
     'poetry',
-    ['export', '--without-hashes', '-f', 'requirements.txt'],
+    ['export', '--without-hashes', '-f', 'requirements.txt', '>', 'requirements.txt'],
     {
       cwd: this.servicePath
     }


### PR DESCRIPTION
Hi, Here is the first attempt at fixing the change in the poetry export command.

The change needed was detailed here: [https://python-poetry.org/docs/cli/#export](url)