### PR TITLE
Correct imprecise regex in moveModuleUp function (fixes #444)

### DIFF
--- a/lib/inject.js
+++ b/lib/inject.js
@@ -67,7 +67,7 @@ function moveModuleUp(source, target, module) {
         file =>
           file.startsWith(module + '/') ||
           file.startsWith('serverless_sdk/') ||
-          file.match(/s_.*\.py/) !== null
+          file.match(/^s_.*\.py/) !== null
       )
     )
     .map(srcZipObj =>


### PR DESCRIPTION
The existing regex had the side effect of matching python files
from other modules if their filename or path happened to contain
the string `s_`.