### PR TITLE
chore(ci): remove bats testing references

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,11 +16,6 @@ jobs:
           ./configure
           make
           sudo make altinstall
-      # install bats
-      - run: |
-          git clone https://github.com/sstephenson/bats.git
-          cd bats
-          sudo ./install.sh /usr/local
       # other deps
       - run: sudo apt -y update && sudo apt -y install python-pip python2.7 curl unzip
       # upgrade python3.6 pip to latest

--- a/test.js
+++ b/test.js
@@ -221,10 +221,6 @@ test('py3.6 can package flask with slim option', t => {
   t.end();
 });
 
-/*
- * News tests NOT in test.bats
- */
-
 test('py3.6 can package flask with slim & slimPatterns options', t => {
   process.chdir('tests/base');
 


### PR DESCRIPTION
In #282 the test suite was ported from BATS to TAPE.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>