### PR TITLE
chore(test): update fixture serverless.yml syntax

### DIFF
--- a/tests/base/serverless.yml
+++ b/tests/base/serverless.yml
@@ -42,7 +42,7 @@ functions:
     handler: handler.hello
   hello3:
     handler: handler.hello
-    runtime: nodejs6.10
+    runtime: nodejs8.10
   hello4:
     handler: fn2_handler.hello
     module: fn2

--- a/tests/individually/serverless.yml
+++ b/tests/individually/serverless.yml
@@ -6,7 +6,8 @@ provider:
 
 package:
   individually: true
-  exclude: 'node_modules/**'
+  exclude:
+    - 'node_modules/**'
 custom:
   pythonRequirements:
     dockerizePip: ${opt:dockerizePip, self:custom.defaults.dockerizePip}


### PR DESCRIPTION
The fixture tests files were raising a couple of warnings on incorrect
YAML structure, based on the Serverless IDE:

https://github.com/threadheap/serverless-ide-vscode/blob/054264da94ed17c42e6e3ba0dd662bd00114e05b/packages/serverless-framework-schema/json/aws/common/runtime.json
https://github.com/threadheap/serverless-ide-vscode/blob/631165a6b5a928ef8f59ba9361af3c6b79a8c38d/packages/serverless-framework-schema/json/common/package-config.json#L13-L19

Signed-off-by: Mike Fiedler <miketheman@gmail.com>