### PR TITLE
Correct tests failing in master

### DIFF
--- a/test.js
+++ b/test.js
@@ -1895,7 +1895,7 @@ test(
   async t => {
     process.chdir('tests/individually');
     const path = npm(['pack', '../..']);
-    const perm = '775';
+    const perm = '755';
     writeFileSync(`module1${sep}foobar`, '');
     chmodSync(`module1${sep}foobar`, perm);
 
@@ -1934,7 +1934,7 @@ test(
   async t => {
     process.chdir('tests/individually');
     const path = npm(['pack', '../..']);
-    const perm = '775';
+    const perm = '755';
     writeFileSync(`module1${sep}foobar`, '', { mode: perm });
     chmodSync(`module1${sep}foobar`, perm);
 

--- a/test.js
+++ b/test.js
@@ -1101,7 +1101,7 @@ test(
   async t => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
-    const perm = '775';
+    const perm = '755';
 
     npm(['i', path]);
     perl([


### PR DESCRIPTION
The executable permissions set in the tests modified should be 755 to work in a zip file. 775 is okay, but the group write gets dropped, which was not what the test was checking.