### PR TITLE
Fix crash with container image lambdas

### DIFF
--- a/lib/inject.js
+++ b/lib/inject.js
@@ -19,6 +19,11 @@ BbPromise.promisifyAll(fse);
 function injectRequirements(requirementsPath, packagePath, options) {
   const noDeploy = new Set(options.noDeploy || []);
 
+  //container image lambda dont have a package path, skip them
+  if (!packagePath) {
+    return;
+  }
+
   return fse
     .readFileAsync(packagePath)
     .then(buffer => JSZip.loadAsync(buffer))


### PR DESCRIPTION
We should skip injection of deps when lambdas are using a container image (and thus do not have a package path)