### PR TITLE
Register `serverless` as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "sha256-file": "1.0.0",
     "shell-quote": "^1.7.2"
   },
+  "peerDependencies": {
+    "serverless": "^1.34 || 2"
+  },
   "eslintConfig": {
     "extends": "eslint:recommended",
     "env": {


### PR DESCRIPTION
It's to ensure only compatible versions or Framework are used together with a plugin, and if mismatch occurs, user is informed with meaningful error message.

_This PR is part of Serverless Framework initiative to [curate most popular plugins](https://github.com/serverless/serverless/issues/9025)_