### PR TITLE
587: Define module property

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,6 +215,12 @@ class ServerlessPythonRequirements {
       'requirements:clean:clean': clean,
       'requirements:cleanCache:cleanCache': cleanCache
     };
+
+    this.serverless.configSchemaHandler.defineFunctionProperties("aws", {
+      properties: {
+        module: { type: "string" }
+      }
+    });
   }
 }
 


### PR DESCRIPTION
Define module property to stop serverless from showing warnings

https://github.com/UnitedIncome/serverless-python-requirements/issues/587