### PR TITLE
Fix help output for `requirements` container command

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,8 +118,6 @@ class ServerlessPythonRequirements {
 
     this.commands = {
       requirements: {
-        usage: 'Serverless plugin to bundle Python packages',
-        lifecycleEvents: ['requirements'],
         commands: {
           clean: {
             usage: 'Remove .requirements and requirements.zip',
@@ -137,6 +135,15 @@ class ServerlessPythonRequirements {
         }
       }
     };
+
+		if (this.serverless.cli.generateCommandsHelp) {
+			Object.assign(this.commands.requirements, {
+				usage: 'Serverless plugin to bundle Python packages',
+				lifecycleEvents: ['requirements']
+			});
+		} else {
+			this.commands.requirements.type = 'container';
+		}
 
     const isFunctionRuntimePython = args => {
       // If functionObj.runtime is undefined, python.


### PR DESCRIPTION
`cli.generateCommandsHelp` was removed with some of the Framework refactors. So currently `sls requirements` produces a programmer error.

This patch fixes the command, with a fallback to old Framework version where `generateCommandsHelp` will remain to be used