### PR TITLE
test: Pin dependencies to avoid unexpected upgrades

### DIFF
--- a/tests/base/requirements.txt
+++ b/tests/base/requirements.txt
@@ -1,3 +1,3 @@
-flask
+flask==0.12.5
 bottle
 boto3


### PR DESCRIPTION
Failing tests on `master` branch were caused by the fact that dependencies that were used were not pinned to specific versions. In the meantime, `Flask` has two major releases, with the last one (2.x) also included a bump in one of the dependencies (Werkzeug), that in newer version depends on `dataclasses` for Python3.6, which interfered in tests that were checking that `dataclasses` library should not be bundled. Pinned down version of `Flask` does not depend on `Werkzeug` that requires `dataclasses` library