### PR TITLE
fix(Packaging): Ensure plugin supports `package.patterns` notation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         run: python -m pip install pipenv poetry
 
       - name: Install serverless
-        run: npm install -g serverless
+        run: npm install -g serverless@2
 
       - name: Install deps
         run: npm install

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -18,13 +18,14 @@ function addVendorHelper() {
     if (this.serverless.service.package.individually) {
       return BbPromise.resolve(this.targetFuncs)
         .map((f) => {
-          if (!get(f, 'package.include')) {
-            set(f, ['package', 'include'], []);
+          if (!get(f, 'package.patterns')) {
+            set(f, ['package', 'patterns'], []);
           }
           if (!get(f, 'module')) {
             set(f, ['module'], '.');
           }
-          f.package.include.push('unzip_requirements.py');
+
+          f.package.patterns.push('unzip_requirements.py');
           return f;
         })
         .then((functions) => uniqBy(functions, (func) => func.module))
@@ -41,11 +42,11 @@ function addVendorHelper() {
     } else {
       this.serverless.cli.log('Adding Python requirements helper...');
 
-      if (!get(this.serverless.service, 'package.include')) {
-        set(this.serverless.service, ['package', 'include'], []);
+      if (!get(this.serverless.service, 'package.patterns')) {
+        set(this.serverless.service, ['package', 'patterns'], []);
       }
 
-      this.serverless.service.package.include.push('unzip_requirements.py');
+      this.serverless.service.package.patterns.push('unzip_requirements.py');
 
       return fse.copyAsync(
         path.resolve(__dirname, '../unzip_requirements.py'),
@@ -106,7 +107,7 @@ function packRequirements() {
           this.serverless.cli.log(
             `Zipping required Python packages for ${f.module}...`
           );
-          f.package.include.push(`${f.module}/.requirements.zip`);
+          f.package.patterns.push(`${f.module}/.requirements.zip`);
           return addTree(
             new JSZip(),
             `.serverless/${f.module}/requirements`
@@ -114,7 +115,7 @@ function packRequirements() {
         });
     } else {
       this.serverless.cli.log('Zipping required Python packages...');
-      this.serverless.service.package.include.push('.requirements.zip');
+      this.serverless.service.package.patterns.push('.requirements.zip');
       return addTree(new JSZip(), '.serverless/requirements').then((zip) =>
         writeZip(zip, path.join(this.servicePath, '.requirements.zip'))
       );

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "shell-quote": "^1.7.2"
   },
   "peerDependencies": {
-    "serverless": "^1.34 || 2"
+    "serverless": "^2.32"
   },
   "eslintConfig": {
     "extends": "eslint:recommended",

--- a/tests/base/serverless.yml
+++ b/tests/base/serverless.yml
@@ -30,9 +30,8 @@ custom:
 
 package:
   individually: ${opt:individually, self:custom.defaults.individually}
-  exclude:
-    - '**/*'
-  include:
+  patterns:
+    - '!**/*'
     - 'handler.py'
 
 functions:
@@ -47,7 +46,7 @@ functions:
     handler: fn2_handler.hello
     module: fn2
     package:
-      include:
+      patterns:
         - 'fn2/**'
   hello5:
     image: 000000000000.dkr.ecr.sa-east-1.amazonaws.com/test-lambda-docker@sha256:6bb600b4d6e1d7cf521097177dd0c4e9ea373edb91984a505333be8ac9455d38

--- a/tests/individually/serverless.yml
+++ b/tests/individually/serverless.yml
@@ -6,8 +6,8 @@ provider:
 
 package:
   individually: true
-  exclude:
-    - 'node_modules/**'
+  patterns:
+    - '!node_modules/**'
 custom:
   pythonRequirements:
     dockerizePip: ${opt:dockerizePip, self:custom.defaults.dockerizePip}

--- a/tests/non_build_pyproject/serverless.yml
+++ b/tests/non_build_pyproject/serverless.yml
@@ -11,10 +11,9 @@ custom:
     usePoetry: false
 
 package:
-  exclude:
-    - '**/*'
-  include:
-    - handler.py
+  patterns:
+    - '!**/*'
+    - 'handler.py'
 
 functions:
   hello:

--- a/tests/non_poetry_pyproject/serverless.yml
+++ b/tests/non_poetry_pyproject/serverless.yml
@@ -8,10 +8,9 @@ plugins:
   - serverless-python-requirements
 
 package:
-  exclude:
-    - '**/*'
-  include:
-    - handler.py
+  patterns:
+    - '!**/*'
+    - 'handler.py'
 
 functions:
   hello:

--- a/tests/pipenv/serverless.yml
+++ b/tests/pipenv/serverless.yml
@@ -21,10 +21,9 @@ custom:
     dockerizePip: false
 
 package:
-  exclude:
-    - '**/*'
-  include:
-    - handler.py
+  patterns:
+    - '!**/*'
+    - 'handler.py'
 
 functions:
   hello:

--- a/tests/poetry/serverless.yml
+++ b/tests/poetry/serverless.yml
@@ -21,10 +21,9 @@ custom:
     dockerizePip: false
 
 package:
-  exclude:
-    - '**/*'
-  include:
-    - handler.py
+  patterns:
+    - '!**/*'
+    - 'handler.py'
 
 functions:
   hello:


### PR DESCRIPTION
Ensure that ahead of `v3` Framework release, plugin supports `package.patterns` notation.

@medikoo Due to an inference between `patterns` and `include` when wide exclusions are concerned (`!src/*` and similar) I had to make this a breaking change. Only other option would be to go back to version inspection. Please let me know what do you think :bow: 