### PR TITLE
feat: Support pipenv users whose Pipfile is not in servicePath (serverless.yml location)

### DIFF
--- a/lib/pipenv.js
+++ b/lib/pipenv.js
@@ -40,14 +40,22 @@ async function getPipenvVersion() {
   }
 }
 
+function findPipfileDirectory(dir) {
+  const { root } = path.parse(dir);
+  while (dir && dir !== root) {
+    if (fse.existsSync(path.join(dir, 'Pipfile'))) {
+      return dir;
+    }
+    dir = path.dirname(dir);
+  }
+  return null;
+}
+
 /**
  * pipenv install
  */
 async function pipfileToRequirements() {
-  if (
-    !this.options.usePipenv ||
-    !fse.existsSync(path.join(this.servicePath, 'Pipfile'))
-  ) {
+  if (!this.options.usePipenv || findPipfileDirectory(this.servicePath) == null){
     return;
   }
 


### PR DESCRIPTION
if you have a project hierarchy like:

```
root/
└── src/
    ├── **/*.py
    ├── test/*.py
    └── serverless.yml
├── .env
├── Pipfile.lock
├── Pipfile
├── README.md
├── mypy.ini
└── pyproject.toml
```

And run sls deploy in the same dir as the serverless.yml like:

`~/MyCode/root/src$ pipenv run sls deploy`

Currently this plugin silently fails to detect your Pipfile. This PR adds code to bubble up until either your operating system's root dir is reached or Pipfile is found. This matches with pipenv's behavior, which is to support executing pipenv commands such as `pipenv run` , `pipenv shell`, and `pipenv requirements` in any subdirectory of a directory containing your Pipfile/the directory where you created your virtualenv.

With this code change, my project hierarchy which looks like the above now successfully packages my serverless project with all of the pipenv generated requirements.

Resolves #857 