### PR TITLE
fix: syncronously create the symlink to the requirements zip

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -51,7 +51,7 @@ function zipRequirements() {
       if (process.platform === 'win32') {
         fse.copySync(zipCachePath, targetZipPath);
       } else {
-        fse.symlink(zipCachePath, targetZipPath, 'file');
+        fse.symlinkSync(zipCachePath, targetZipPath, 'file');
       }
     }
   });


### PR DESCRIPTION
Currently, the symlink is created asynchronously. On a 14-CPUs MacBook Pro the current code leads to a raise condition - the symlink not yet existing during subsequent attempy to use it, but existing afterward. This happens in ~90% of the invocations:

Serverless: Packaging Python Requirements Lambda Layer...
Serverless: Found cached Python Requirements Lambda Layer file
 
 Exception -----------------------------------------------
 
  OperationalError: ENOENT: no such file or directory, open '/Users/XXXX/git/YYYY/.serverless/pythonRequirements.zip'
 
Patching the code locally as proposed, fixes the problem.

Also, making the symlinkSync() call will be consistent with making the copySync() call in the adjacent if(...) statement branch.